### PR TITLE
fix crash issue in MOM_SIS when compiling with openmp

### DIFF
--- a/src/core/MOM_continuity_PPM.F90
+++ b/src/core/MOM_continuity_PPM.F90
@@ -411,8 +411,9 @@ subroutine zonal_mass_flux(u, h_in, uh, dt, G, CS, LB, uhbt, OBC, &
 
   call cpu_clock_begin(id_clock_correct)
 !$OMP parallel do default(shared) private(i, j, k, do_i, duhdu, du, &
-!$OMP               du_max_CFL, du_min_CFL, uh_tot_0, duhdu_tot_0, visc_rem, &
-!$OMP               visc_rem_max, I_vrm, du_lim, dx_E, dx_W )
+!$OMP               du_max_CFL, du_min_CFL, uh_tot_0, duhdu_tot_0, &
+!$OMP               visc_rem_max, I_vrm, du_lim, dx_E, dx_W, any_simple_OBC ) &   
+!$OMP      firstprivate(visc_rem)
   do j=jsh,jeh
     do I=ish-1,ieh ; do_i(I) = .true. ; visc_rem_max(I) = 0.0 ; enddo
     ! Set uh and duhdu.
@@ -1146,8 +1147,9 @@ subroutine meridional_mass_flux(v, h_in, vh, dt, G, CS, LB, vhbt, OBC, &
 
   call cpu_clock_begin(id_clock_correct)
 !$OMP parallel do default(shared) private(i, j, k, do_i, dvhdv, dv, &
-!$OMP               dv_max_CFL, dv_min_CFL, vh_tot_0, dvhdv_tot_0, visc_rem, &
-!$OMP               visc_rem_max, I_vrm, dv_lim, dy_N, dy_S )
+!$OMP               dv_max_CFL, dv_min_CFL, vh_tot_0, dvhdv_tot_0,  &
+!$OMP               visc_rem_max, I_vrm, dv_lim, dy_N, dy_S,any_simple_OBC ) &
+!$OMP     firstprivate(visc_rem)
   do J=jsh-1,jeh
     do i=ish,ieh ; do_i(i) = .true. ; visc_rem_max(I) = 0.0 ; enddo
     ! This sets vh and dvhdv.


### PR DESCRIPTION
Using tikal_201304 and MOM6 dev/master, all MOM6_SIS test cases crash when compiled with -openmp with:

FATAL from PE    30: NaN in input field of reproducing_sum(_2d).

This is the xml and fre commands to reproduce the issue:

/ncrc/home2/Niki.Zadeh/frerts/tikal_201403_devmaster20140313/_0/MOM6_SIS.xml.20140313201957

fremake --execute --nolink -x /ncrc/home2/Niki.Zadeh/frerts/tikal_201403_devmaster20140313/_0/MOM6_SIS.xml.20140313201957 -p ncrc2.intel -t repro-openmp MOM6_SIS_libs_compile

fremake --execute -x /ncrc/home2/Niki.Zadeh/frerts/tikal_201403_devmaster20140313/_0/MOM6_SIS.xml.20140313201957 -p ncrc2.intel -t repro-openmp MOM6_SIS_compile

frerun -s -r basic -u --no-transfer --partition t1 -x /ncrc/home2/Niki.Zadeh/frerts/tikal_201403_devmaster20140313/_0/MOM6_SIS.xml.20140313201957 -p ncrc2.intel -t repro-openmp MOM6_GOLD_SIS

Or you can try the following command to build and run the test:

/ncrc/home2/Niki.Zadeh/fre/fre-commands/bin/frerts_batch.csh -p ncrc2.intel -t repro-openmp --release tikal_201403 --fre_stem tikal_201403_devmaster20140313 --mom_git_tag 'dev\\/master' -x /ncrc/home2/Niki.Zadeh/xmls/tikal_f1/xml/MOM6_SIS.xml --frerts_ops '--no_rts,--compile,-l,MOM6_SIS_libs_compile,--fre_ops,-u;--no-transfer;--partition=t1,--do_frecheck,--reference_tag,tikal_mom6_2014.01.17' --fre_version 'fre\\/bronx-7' --mom_git_tag 'dev\\/master' --debuglevel _0 --interactive
MOM6_GOLD_SIS

These  the stdouts for openmp and regular runs:

/lustre/f1/Niki.Zadeh/tikal_201403_devmaster20140313_0/MOM6_GOLD_SIS/ncrc2.intel-repro-openmp/stdout/run/MOM6_GOLD_SIS_1x0m20d_32pe.o5031341
/lustre/f1/Niki.Zadeh/tikal_201403_devmaster20140313_0/MOM6_GOLD_SIS/ncrc2.intel-repro/stdout/run/MOM6_GOLD_SIS_1x0m20d_32pe.o5031270
