### PR TITLE
Added new scalar diagnostic, SSS_global

### DIFF
--- a/examples/ocean_SIS/MOM6z_SIS_025/diag_table
+++ b/examples/ocean_SIS/MOM6z_SIS_025/diag_table
@@ -7,6 +7,7 @@ MOM_SIS_025_z
 "ocean_month",    1, "months", 1, "days", "time"
 "ocean_annual",  12, "months", 1, "days", "time"
 "ocean_static",  -1, "months", 1, "days", "time"
+"ocean_scalar_daily", 1, "days",   1, "days", "time"
 "_Drake_passage",    1, "days",   1, "days", "time"
 "_Denmark_Strait",   1, "days",   1, "days", "time"
 "_Iceland_Norway",   1, "days",   1, "days", "time"
@@ -116,6 +117,12 @@ MOM_SIS_025_z
  "ocean_model", "wet_c",       "wet_c",       "ocean_static", "all", .false., "none", 2
  "ocean_model", "wet_u",       "wet_u",       "ocean_static", "all", .false., "none", 2
  "ocean_model", "wet_v",       "wet_v",       "ocean_static", "all", .false., "none", 2
+
+
+# Scalar diagnostics
+ "ocean_model", "SST_global",   "SST_global",       "ocean_scalar_daily", "all", .true., "none", 2
+ "ocean_model", "SSS_global",   "SSS_global",       "ocean_scalar_daily", "all", .true., "none", 2
+
 
 #================
 # ICE DIAGNOSTICS


### PR DESCRIPTION
Verified that timestats.intel did not change in the 0.25 deg MOM-SIS example. but did not run the full suite of tests.
