### PR TITLE
Fix the potential crash when nstep+nfilter=0

### DIFF
--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -775,8 +775,6 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
   if (.not. use_BT_cont) then
     call  create_group_pass(pass_Dat_uv, Datu, Datv, CS%BT_Domain, To_All+Scalar_Pair)
   endif
-  call create_group_pass(pass_eta_ubt, eta, CS%BT_Domain)
-  call create_group_pass(pass_eta_ubt, ubt, vbt, CS%BT_Domain)
   if (find_etaav) then
     call create_group_pass(pass_etaav, etaav, G%Domain)
   endif
@@ -1440,6 +1438,12 @@ subroutine btstep(U_in, V_in, eta_in, dt, bc_accel_u, bc_accel_v, &
     dt_filt = 0.5 * max(0.0, dt * min(-CS%dt_bt_filter, 2.0))
   endif
   nfilter = ceiling(dt_filt / dtbt)
+
+  !--- setup group update for pass_eta_ubt only when nstep+nfilter>0 
+  if(nstep+nfilter>0) then
+    call create_group_pass(pass_eta_ubt, eta, CS%BT_Domain)
+    call create_group_pass(pass_eta_ubt, ubt, vbt, CS%BT_Domain)
+  endif
 
   ! Set up the normalized weights for the filtered velocity.
   sum_wt_vel = 0.0 ; sum_wt_eta = 0.0 ; sum_wt_accel = 0.0 ; sum_wt_trans = 0.0


### PR DESCRIPTION
Solve the potential crash at calling create_group_update when number of barotropic step is 0 (nstep+nfilter=0)
