### PR TITLE
Make sis2 use the mask_table

### DIFF
--- a/examples/ocean_SIS2/OM4_025/MOM_layout
+++ b/examples/ocean_SIS2/OM4_025/MOM_layout
@@ -1,6 +1,10 @@
 ! These parameters are for testing mask_tables in a non-FRE environment.
 ! This file should not be used in production unless you really want to
 ! use this layout.
-#override NIPROC = 32
-#override NJPROC = 18
+#override undef NIPROC
+#override undef NJPROC
+#override undef NIPROC_IO
+#override undef NJPROC_IO
+#override LAYOUT = 32,18
+#override IO_LAYOUT = 2,2
 #override MASKTABLE = "mask_table.96.32x18" ! 32*18-96 = 480 PEs

--- a/examples/ocean_SIS2/OM4_025/MOM_override
+++ b/examples/ocean_SIS2/OM4_025/MOM_override
@@ -1,3 +1,2 @@
 ! Blank file in which we can put "overrides" for parameters
-#override IO_LAYOUT = 2, 2
 !VERBOSITY = 9

--- a/examples/ocean_SIS2/OM4_025/MOM_parameter_doc.all
+++ b/examples/ocean_SIS2/OM4_025/MOM_parameter_doc.all
@@ -54,7 +54,7 @@ MASKTABLE = "mask_table.96.32x18" ! default = "MOM_mask_table"
                                 !  4,6
                                 !  1,2
                                 !  3,6
-LAYOUT = 0, 0                   ! default = 0
+LAYOUT = 32, 18                 ! default = 0
                                 ! The processor layout to be used, or 0, 0 to automatically
                                 ! set the layout based on the number of processors.
 !NIPROC = 32                    !

--- a/examples/ocean_SIS2/OM4_025/MOM_parameter_doc.short
+++ b/examples/ocean_SIS2/OM4_025/MOM_parameter_doc.short
@@ -48,6 +48,9 @@ MASKTABLE = "mask_table.96.32x18" ! default = "MOM_mask_table"
                                 !  4,6
                                 !  1,2
                                 !  3,6
+LAYOUT = 32, 18                 ! default = 0
+                                ! The processor layout to be used, or 0, 0 to automatically
+                                ! set the layout based on the number of processors.
 !NIPROC = 32                    !
                                 ! The number of processors in the x-direction. With
                                 ! STATIC_MEMORY_ this is set in MOM_memory.h at compile time.

--- a/examples/ocean_SIS2/OM4_025/SIS_layout
+++ b/examples/ocean_SIS2/OM4_025/SIS_layout
@@ -1,7 +1,10 @@
 ! These parameters are for testing mask_tables in a non-FRE environment.
 ! This file should not be used in production unless you really want to
 ! use this layout.
-#override undef LAYOUT
-#override NIPROC = 32
-#override NJPROC = 18
+#override undef NIPROC
+#override undef NJPROC
+#override undef NIPROC_IO
+#override undef NJPROC_IO
+#override LAYOUT = 32,18
+#override IO_LAYOUT = 2,2
 #override MASKTABLE = "mask_table.96.32x18" ! 32*18-96 = 480 PEs

--- a/examples/ocean_SIS2/OM4_025/SIS_parameter_doc.all
+++ b/examples/ocean_SIS2/OM4_025/SIS_parameter_doc.all
@@ -122,7 +122,7 @@ NJGLOBAL = 1080                 !
                                 ! The total number of thickness grid points in the
                                 ! y-direction in the physical domain. With STATIC_MEMORY_
                                 ! this is set in SIS2_memory.h at compile time.
-MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
+MASKTABLE = "mask_table.96.32x18" ! default = "MOM_mask_table"
                                 ! A text file to specify n_mask, layout and mask_list.
                                 ! This feature masks out processors that contain only land points.
                                 ! The first line of mask_table is the number of regions to be masked out.
@@ -137,18 +137,18 @@ MASKTABLE = "MOM_mask_table"    ! default = "MOM_mask_table"
                                 !  4,6
                                 !  1,2
                                 !  3,6
-LAYOUT = 0, 1                   ! default = 0
+LAYOUT = 32, 18                 ! default = 0
                                 ! The processor layout to be used, or 0, 0 to automatically
                                 ! set the layout based on the number of processors.
-!NIPROC = 480                   !
+!NIPROC = 32                    !
                                 ! The number of processors in the x-direction. With
                                 ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
-!NJPROC = 1                     !
+!NJPROC = 18                    !
                                 ! The number of processors in the x-direction. With
                                 ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
-!LAYOUT = 480, 1                !
+!LAYOUT = 32, 18                !
                                 ! The processor layout that was acutally used.
-IO_LAYOUT = 1, 1                ! default = 0
+IO_LAYOUT = 2, 2                ! default = 0
                                 ! The processor layout to be used, or 0,0 to automatically
                                 ! set the io_layout to be the same as the layout.
 GLOBAL_INDEXING = False         !   [Boolean] default = False

--- a/examples/ocean_SIS2/OM4_025/SIS_parameter_doc.short
+++ b/examples/ocean_SIS2/OM4_025/SIS_parameter_doc.short
@@ -33,18 +33,33 @@ NJGLOBAL = 1080                 !
                                 ! The total number of thickness grid points in the
                                 ! y-direction in the physical domain. With STATIC_MEMORY_
                                 ! this is set in SIS2_memory.h at compile time.
-LAYOUT = 0, 1                   ! default = 0
+MASKTABLE = "mask_table.96.32x18" ! default = "MOM_mask_table"
+                                ! A text file to specify n_mask, layout and mask_list.
+                                ! This feature masks out processors that contain only land points.
+                                ! The first line of mask_table is the number of regions to be masked out.
+                                ! The second line is the layout of the model and must be
+                                ! consistent with the actual model layout.
+                                ! The following (n_mask) lines give the logical positions
+                                ! of the processors that are masked out. The mask_table
+                                ! can be created by tools like check_mask. The
+                                ! following example of mask_table masks out 2 processors,
+                                ! (1,2) and (3,6), out of the 24 in a 4x6 layout:
+                                !  2
+                                !  4,6
+                                !  1,2
+                                !  3,6
+LAYOUT = 32, 18                 ! default = 0
                                 ! The processor layout to be used, or 0, 0 to automatically
                                 ! set the layout based on the number of processors.
-!NIPROC = 480                   !
+!NIPROC = 32                    !
                                 ! The number of processors in the x-direction. With
                                 ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
-!NJPROC = 1                     !
+!NJPROC = 18                    !
                                 ! The number of processors in the x-direction. With
                                 ! STATIC_MEMORY_ this is set in SIS2_memory.h at compile time.
-!LAYOUT = 480, 1                !
+!LAYOUT = 32, 18                !
                                 ! The processor layout that was acutally used.
-IO_LAYOUT = 1, 1                ! default = 0
+IO_LAYOUT = 2, 2                ! default = 0
                                 ! The processor layout to be used, or 0,0 to automatically
                                 ! set the io_layout to be the same as the layout.
 GRID_FILE = "ocean_hgrid.nc"    !

--- a/examples/ocean_SIS2/OM4_025/input.nml
+++ b/examples/ocean_SIS2/OM4_025/input.nml
@@ -15,7 +15,7 @@
         restart_input_dir = 'INPUT/',
         restart_output_dir = 'RESTART/',
         parameter_filename = 'SIS_input',
-!                             'SIS_layout',
+                             'SIS_layout',
                              'SIS_override' /
 
  &atmos_model_nml


### PR DESCRIPTION
- The SIS_layout in input.nml was commented out and sis2 was not using the mask_table.
  Although SIS2 was smart enough to make use of the 480 pes passed to it.
- MOM_override was not empty and IO_LAYOUT was there!
- MOM_layout and SIS_layout were setting NIPROC,NJPROC rather than LAYOUT which is the preferred way.
- timestats do not change.
