### PR TITLE
*New OBLdepth calculation based on POP approach. Ans changes*

### DIFF
--- a/src/parameterizations/vertical/MOM_KPP.F90
+++ b/src/parameterizations/vertical/MOM_KPP.F90
@@ -154,7 +154,7 @@ logical function KPP_init(paramFile, G, diag, Time, CS, passive)
   call get_param(paramFile, mod, 'INTERP_TYPE', CS%interpType,                  &
                  'Type of interpolation to use to determine the OBL depth.\n'// &
                  'Allowed types are: linear, quadratic, cubic.',                &
-                 default='quadratic')
+                 default='cubic')
   call get_param(paramFile, mod, 'COMPUTE_EKMAN', CS%computeEkman,                     &
                  'If True, limit the OBL depth to be shallower than the Ekman depth.', &
                  default=.False.)


### PR DESCRIPTION
Modifications to the OBLdepth calculation based now on what
is done by POP.  New results found to be insensitive to the
"correction" step, since the first pass now properly accounts
for the thickness of the surface layer.  This new approach
changes answers, but not by much.  New algorithm is
faster (since no need to perform the correction step) and
easier to understand.

These changes need to be tested in all expts that use KPP. 
