### PR TITLE
Recover topography clipping when not specifying MINIMUM_DEPTH

### DIFF
--- a/src/initialization/MOM_grid_initialize.F90
+++ b/src/initialization/MOM_grid_initialize.F90
@@ -9,7 +9,7 @@ use MOM_domains,       only : AGRID, BGRID_NE, CGRID_NE, To_All, Scalar_Pair
 use MOM_domains,       only : To_North, To_South, To_East, To_West
 use MOM_domains,       only : MOM_domain_type, clone_MOM_domain, deallocate_MOM_domain
 use MOM_dyn_horgrid,   only : dyn_horgrid_type, set_derived_dyn_horgrid
-use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, WARNING, is_root_pe
+use MOM_error_handler, only : MOM_error, MOM_mesg, FATAL, is_root_pe
 use MOM_error_handler, only : callTree_enter, callTree_leave
 use MOM_file_parser,   only : get_param, log_param, log_version, param_file_type
 use MOM_io,            only : MOM_read_data, slasher, file_exists, stdout

--- a/src/initialization/MOM_shared_initialization.F90
+++ b/src/initialization/MOM_shared_initialization.F90
@@ -433,21 +433,21 @@ subroutine limit_topography(D, G, param_file, max_depth, US)
   ! TBD: The following f.p. equivalence uses a special value. Originally, any negative value
   !      indicated the branch. We should create a logical flag to indicate this branch.
   if (mask_depth == -9999.*m_to_Z) then
-    if (min_depth > 0.0) then
-      ! This is the old path way. The 0.5*min_depth is obscure and is retained to be
-      ! backward reproducible. If you are looking at the following line you should probably
-      ! set MASKING_DEPTH.
-      do j=G%jsd,G%jed ; do i=G%isd,G%ied
-        D(i,j) = min( max( D(i,j), 0.5*min_depth ), max_depth )
-      enddo ; enddo
-    else
-      do j=G%jsd,G%jed ; do i=G%isd,G%ied
-        D(i,j) = min( max( D(i,j), min_depth ), max_depth )
-      enddo ; enddo
+    if (min_depth<0.) then
+      call MOM_error(FATAL, trim(mdl)//": MINIMUM_DEPTH<0 does not work as expected "//&
+                 "unless MASKING_DEPTH has been set appropriately. Set a meaningful "//&
+                 "MASKING_DEPTH to enabled negative depths (land elevations) and to "//&
+                 "enable flooding.")
     endif
+    ! This is the old path way. The 0.5*min_depth is obscure and is retained to be
+    ! backward reproducible. If you are looking at the following line you should probably
+    ! set MASKING_DEPTH. This path way does not work for negative depths, i.e. flooding.
+    do j=G%jsd,G%jed ; do i=G%isd,G%ied
+      D(i,j) = min( max( D(i,j), 0.5*min_depth ), max_depth )
+    enddo ; enddo
   else
     ! This is the preferred path way.
-    ! mask_depth has a meaningful value; anything shallower that mask_depth is land.
+    ! mask_depth has a meaningful value; anything shallower than mask_depth is land.
     ! If min_depth<mask_depth (which happens when using positive depths and not changing
     ! MINIMUM_DEPTH) then the shallower is used to modify and determine values on land points.
     do j=G%jsd,G%jed ; do i=G%isd,G%ied


### PR DESCRIPTION
PRs #1428 and #1457 extended the topography clipping to allow flooding but missed the use case for positive-only depths where the MASKING_DEPTH parameter alone was in use. There were two bugs:
1. The new code assumed that MINIMUM_DEPTH would be deeper than  MASKING_DEPTH (which is intuitive). However, the point of MASKING_DEPTH was only to specify the determination of the land mask. The new code assigned depths the value of MASKING_DEPTH which broke cases that were using MASKING_DEPTH as documented and were leaving MINIMUM_DEPTH=0.
2. The values of variable masking_depth were altered and subsequently not consistent with the logged parameters. A warning was issued but the behavior was nevertheless not as intended.
3. Corrected documentation to retain original purpose of MASKING_DEPTH
4. Added some comments for declaration with units
5. Added some clarifying comments in code

Changes:
1. Removed the test that masking_depth > min_depth, and warning
2. Adjusted the condition and assigned value when clipping depths. This now uses the shallower of min_depth and masking_depth to decide when to clip and for the value to use otherwise. The expression for the land mask is unaltered.