### PR TITLE
Removed but in DOME2D temperature initialization

### DIFF
--- a/src/user/DOME2d_initialization.F90
+++ b/src/user/DOME2d_initialization.F90
@@ -332,7 +332,6 @@ subroutine DOME2d_initialize_temperature_salinity ( T, S, h, G, GV, param_file, 
   endif
 
   ! Modify temperature when rho coordinates are used
-  T(G%isc:G%iec,G%jsc:G%jec,1:GV%ke) = 0.0
   if (( coordinateMode(verticalCoordinate) == REGRIDDING_RHO ) .or. &
       ( coordinateMode(verticalCoordinate) == REGRIDDING_LAYER )) then
     do i = G%isc,G%iec ; do j = G%jsc,G%jec


### PR DESCRIPTION
This fixes the comparison between the four coordinates: z, sigma, rho, layer.
![Screen Shot 2022-03-21 at 3 54 59 PM](https://user-images.githubusercontent.com/12971166/159353619-d9bdd8e6-514a-4c21-8e7b-b712b387ea60.png)

