### PR TITLE
Add missing h_neglect

### DIFF
--- a/src/core/MOM_isopycnal_slopes.F90
+++ b/src/core/MOM_isopycnal_slopes.F90
@@ -257,7 +257,7 @@ subroutine calc_isoneutral_slopes(G, GV, US, h, e, tv, dt_kappa_smooth, &
       hg2B = h(i,j,k)*h(i+1,j,k) + h_neglect2
       hg2L = h(i,j,k-1)*h(i,j,k) + h_neglect2
       hg2R = h(i+1,j,k-1)*h(i+1,j,k) + h_neglect2
-      haA = 0.5*(h(i,j,k-1) + h(i+1,j,k-1))
+      haA = 0.5*(h(i,j,k-1) + h(i+1,j,k-1)) + h_neglect
       haB = 0.5*(h(i,j,k) + h(i+1,j,k)) + h_neglect
       haL = 0.5*(h(i,j,k-1) + h(i,j,k)) + h_neglect
       haR = 0.5*(h(i+1,j,k-1) + h(i+1,j,k)) + h_neglect


### PR DESCRIPTION
Looks like the addition of `h_neglect` is missing in one line for the computation of zonal isopycnal slopes.

Note that is is correctly added in the meridional counterpart:
https://github.com/mom-ocean/MOM6/blob/399a7db1565e89e0ac8aeedd2de32bc846b1f230/src/core/MOM_isopycnal_slopes.F90#L363-L370