### PR TITLE
Fix for https://github.com/mom-ocean/MOM6/issues/1572

### DIFF
--- a/src/framework/MOM_unique_scales.F90
+++ b/src/framework/MOM_unique_scales.F90
@@ -266,6 +266,8 @@ integer function non_unique_scales(scales, list, descs, weights, silent)
   integer :: ndim           ! The number of dimensional scaling factors to work with
   integer :: i, n, m, ns
 
+  non_unique_scales = -9999 ! Set return value to a _dummy_ value
+
   verbose = .true. ; if (present(silent)) verbose = .not.silent
 
   ndim = size(scales)


### PR DESCRIPTION
This PR addresses https://github.com/mom-ocean/MOM6/issues/1572 with a simple _fix_.

✅ Verified that `VERBOSITY = 9` runs through. 

For reference, my `MOM_parameter_doc.all` and `MOM_parameter_doc.debugging` are included. (For compiler and its flags please see [comment](https://github.com/mom-ocean/MOM6/issues/1572#issuecomment-1147925129); my build is _debug_ type.)

Thanks for reviewing.

[MOM_parameter_doc.all.txt](https://github.com/mom-ocean/MOM6/files/8848672/MOM_parameter_doc.all.txt)
[MOM_parameter_doc.debugging.txt](https://github.com/mom-ocean/MOM6/files/8848673/MOM_parameter_doc.debugging.txt)

