### PR TITLE
GNU bug fix for MOM_variables.F90

### DIFF
--- a/src/core/MOM_variables.F90
+++ b/src/core/MOM_variables.F90
@@ -261,7 +261,7 @@ type, public :: vertvisc_type
 
   ! The following elements are pointers so they can be used as targets for pointers in the restart registry.
   real, pointer, dimension(:,:) :: MLD => NULL() !< Instantaneous active mixing layer depth [Z ~> m].
-  real, pointer, dimension(:,:) :: sfc_buoy_flx !< Surface buoyancy flux (derived) [Z2 T-3 ~> m2 s-3].
+  real, pointer, dimension(:,:) :: sfc_buoy_flx => NULL() !< Surface buoyancy flux (derived) [Z2 T-3 ~> m2 s-3].
   real, pointer, dimension(:,:,:) :: Kd_shear => NULL()
                 !< The shear-driven turbulent diapycnal diffusivity at the interfaces between layers
                 !! in tracer columns [Z2 T-1 ~> m2 s-1].


### PR DESCRIPTION
Upon the update of MOM6 in GEOS-ESM to the latest code, our CI GNU Debug testing threw a failure:

https://app.circleci.com/pipelines/github/GEOS-ESM/GEOSgcm/2849/workflows/cb295ace-751c-439c-9ad4-b1922a7c4cc7/jobs/5573/parallel-runs/0/steps/0-105

Tracing it back to line 1390 in `src/parameterizations/vertical/MOM_diabatic_driver.F90`

https://github.com/mom-ocean/MOM6/blob/b61b29ec1611ee222fcd114ee2b667bbe98ce8f4/src/parameterizations/vertical/MOM_diabatic_driver.F90#L1389-L1392

Experience with GNU tells us that GNU does not handle pointers that aren't nullified and not associated well. So `associated(pointer)` could be true, could be false, or unknown. I think the Fortran Standard says it's an undefined state.

The fix is simple though. Null the pointer in the derived type declaration. It also matches all the other pointers which are that way. 

(For reference, this change came in via https://github.com/mom-ocean/MOM6/pull/1603 through https://github.com/NOAA-GFDL/MOM6/pull/352 it looks like.)
