### PR TITLE
Update .readthedocs.yml configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,13 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 # Extra formats
 # PDF generation is failing for now; disabled on 2020-12-02
@@ -10,7 +19,5 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  # make sure we're using Python 3
-  version: 3
   install:
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,5 @@ sphinxcontrib-bibtex
 numpy
 six
 future
+# Old Sphinx requires an old Jinja2
+jinja2<3.1


### PR DESCRIPTION
Newest Read the Docs configuration file requires explicit specification of the environment (using `build:`).  This patch includes this section.

Upgrading to newer Python environments has also forced us to specify an older Jinja2 that works with our legacy Sphinx module.