### PR TITLE
fix incorrect indexing for v-point in documentation

### DIFF
--- a/src/framework/_Horizontal_indexing.dox
+++ b/src/framework/_Horizontal_indexing.dox
@@ -25,7 +25,7 @@ For example, when a loop is over h-points collocated variables
 - the do-loop statements will be for lower-case `i,j` variables
 - references to h-point variables will be `h(i,j)`, `D(i+1,j)`, etc.
 - references to u-point variables will be `u(I,j)` (meaning \f$u_{i+\frac{1}{2},j}\f$), `u(I-1,j)` (meaning \f$u_{i-\frac{1}{2},j}\f$), etc.
-- references to v-point variables will be `v(i,J)` (meaning \f$v_{i,j+\frac{1}{2}}\f$), `u(I-1,j)` (meaning \f$u_{i,j-\frac{1}{2}}\f$), etc.
+- references to v-point variables will be `v(i,J)` (meaning \f$v_{i,j+\frac{1}{2}}\f$), `v(i,J-1)` (meaning \f$v_{i,j-\frac{1}{2}}\f$), etc.
 - references to q-point variables will be `q(I,J)` (meaning \f$q_{i+\frac{1}{2},j+\frac{1}{2}}\f$), etc.
 
 In contrast, when a loop is over u-points collocated variables


### PR DESCRIPTION
This PR fix a typo in the MOM6 documentation when illustrating the index for v-point.

The current doc with the typo is at (https://mom6.readthedocs.io/en/main/api/generated/pages/Horizontal_Indexing.html)

Under Section "Soft convention for loop variables", the reference for v-point is incorrect. See the screenshot here:
![Screenshot 2025-03-27 at 12 49 20 PM](https://github.com/user-attachments/assets/08924fe4-06c5-4fd1-a6e6-f9564ea62a1b)

The later one should be `v(i,J-1)` and `\f$v_{i,j-\frac{1}{2}}\f$`