### PR TITLE
Docs: Force CMake 3.5 compatibility

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -195,8 +195,8 @@ doxygen:
 	git clone -b $(DOXYGEN_RELEASE) --depth 1 https://github.com/doxygen/doxygen
 
 doxygen/bin/doxygen: doxygen
-	(cd $(<); cmake -G "Unix Makefiles" .)
-	(cd $(<); make)
+	(cd $(<); cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -G "Unix Makefiles" .)
+	(cd $(<); $(MAKE))
 
 nortd: $(DOXYGENBIN) $(BUILDDIR)
 ifdef DOXYGEN_CONF


### PR DESCRIPTION
The Doxygen CMake build compatibility is increase to 3.5 in order to enable usage of newer versions of CMake.

This is not ideal, and is an indication that we need to overhaul and update our documentation software stack, but this is a short-term solution.

Thanks to @mnlevy1981 for identifying and investigating this issue.