### PR TITLE
+*Update parameter defaults for 2024 and 2025, including EQN_OF_STATE

### DIFF
--- a/.testing/tc0/MOM_input
+++ b/.testing/tc0/MOM_input
@@ -235,7 +235,7 @@ DIAG_AS_CHKSUM = True
 DEBUG = True
 GRID_ROTATION_ANGLE_BUGS = True !   [Boolean] default = True
 USE_GM_WORK_BUG = True          !   [Boolean] default = True
-FIX_UNSPLIT_DT_VISC_BUG = False !   [Boolean] default = False
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
 GUST_CONST = 0.02               !   [Pa] default = 0.02
 FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = False
+

--- a/.testing/tc1.a/MOM_tc_variant
+++ b/.testing/tc1.a/MOM_tc_variant
@@ -1,2 +1,2 @@
 #override SPLIT=False
-#override FIX_UNSPLIT_DT_VISC_BUG = False !   [Boolean] default = False
+#override UNSPLIT_DT_VISC_BUG = True      !   [Boolean] default = False

--- a/.testing/tc1.b/MOM_tc_variant
+++ b/.testing/tc1.b/MOM_tc_variant
@@ -1,3 +1,3 @@
 #override SPLIT=False
 #override USE_RK2=True
-#override FIX_UNSPLIT_DT_VISC_BUG = False !   [Boolean] default = False
+#override UNSPLIT_DT_VISC_BUG = True      !   [Boolean] default = False

--- a/.testing/tc1/MOM_input
+++ b/.testing/tc1/MOM_input
@@ -595,3 +595,17 @@ BULKML_CONV_MOMENTUM_BUG = True !   [Boolean] default = True
 PEN_SW_ABSORB_MINTHICK = 0.001  !   [m] default = 0.001
 GUST_CONST = 0.02               !   [Pa] default = 0.02
 FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = False
+
+
+! Explicitly use the defaults from late 2024
+EQN_OF_STATE = "WRIGHT"     ! default = "WRIGHT_FULL"
+HOR_DIFF_ANSWER_DATE = 20240101
+HOR_DIFF_LIMIT_BUG = True
+
+! Explicitly use the defaults from early 2025
+VISC_REM_BUG = True
+DRAG_DIFFUSIVITY_ANSWER_DATE = 20250101
+FRICTWORK_BUG = True
+HOR_DIFF_ANSWER_DATE = 20240101
+HOR_DIFF_LIMIT_BUG = True
+MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP = False

--- a/.testing/tc2/MOM_input
+++ b/.testing/tc2/MOM_input
@@ -627,3 +627,16 @@ USE_MLD_ITERATION = False       !   [Boolean] default = False
 PEN_SW_ABSORB_MINTHICK = 0.001  !   [m] default = 0.001
 GUST_CONST = 0.02               !   [Pa] default = 0.02
 FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = False
+
+! Explicitly use the defaults from late 2024
+EQN_OF_STATE = "WRIGHT"     ! default = "WRIGHT_FULL"
+TIDES_ANSWER_DATE = 20230630
+NDIFF_ANSWER_DATE = 20240101
+BACKSCATTER_UNDERBOUND = True
+
+! Explicitly use the defaults from early 2025
+VISC_REM_BUG = True
+DRAG_DIFFUSIVITY_ANSWER_DATE = 20250101
+FRICTWORK_BUG = True
+NDIFF_ANSWER_DATE = 20240101
+MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP = False

--- a/.testing/tc3/MOM_input
+++ b/.testing/tc3/MOM_input
@@ -480,3 +480,8 @@ KAPPA_SHEAR_ITER_BUG = True     !   [Boolean] default = True
 KAPPA_SHEAR_ALL_LAYER_TKE_BUG = True !   [Boolean] default = True
 GUST_CONST = 0.02               !   [Pa] default = 0.02
 FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = False
+
+! Explicitly use the defaults from early 2025
+VISC_REM_BUG = True
+DRAG_DIFFUSIVITY_ANSWER_DATE = 20250101
+FRICTWORK_BUG = True

--- a/.testing/tc4/MOM_input
+++ b/.testing/tc4/MOM_input
@@ -411,9 +411,12 @@ DEBUG = True
 
 INTERPOLATE_RES_FN = True       !   [Boolean] default = True
 GILL_EQUATORIAL_LD = False      !   [Boolean] default = False
-FIX_UNSPLIT_DT_VISC_BUG = False !   [Boolean] default = False
 USE_LAND_MASK_FOR_HVISC = False !   [Boolean] default = False
 KAPPA_SHEAR_ITER_BUG = True     !   [Boolean] default = True
 KAPPA_SHEAR_ALL_LAYER_TKE_BUG = True !   [Boolean] default = True
 USE_MLD_ITERATION = False       !   [Boolean] default = False
 
+! Explicitly use the defaults from early 2025
+VISC_REM_BUG = True
+FRICTWORK_BUG = True
+MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP = False

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -313,7 +313,7 @@ subroutine initialize_regridding(CS, GV, US, max_depth, param_file, mdl, coord_m
                  "Values below 20190101 result in the use of older, less accurate expressions "//&
                  "that were in use at the end of 2018.  Higher values result in the use of more "//&
                  "robust and accurate forms of mathematically equivalent expressions.", &
-                 default=20181231, do_not_log=.not.GV%Boussinesq) ! ### change to default=default_answer_date)
+                 default=default_answer_date, do_not_log=.not.GV%Boussinesq)
     if (.not.GV%Boussinesq) regrid_answer_date = max(regrid_answer_date, 20230701)
     call set_regrid_params(CS, regrid_answer_date=regrid_answer_date)
   endif

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -2076,8 +2076,10 @@ subroutine PressureForce_FV_init(Time, G, GV, US, param_file, diag, CS, ADp, SAL
                  default=enable_bugs)
   call get_param(param_file, mdl, "TIDES", CS%tides, &
                  "If true, apply tidal momentum forcing.", default=.false.)
-  call get_param(param_file, '', "DEFAULT_ANSWER_DATE", default_answer_date, default=99991231)
-  if (CS%tides) &
+  if (CS%tides) then
+    call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
+                 "This sets the default value for the various _ANSWER_DATE parameters.", &
+                 default=99991231)
     call get_param(param_file, mdl, "TIDES_ANSWER_DATE", CS%tides_answer_date, "The vintage of "//&
                   "self-attraction and loading (SAL) and tidal forcing calculations.  Setting "//&
                   "dates before 20230701 recovers old answers (Boussinesq and non-Boussinesq "//&
@@ -2085,7 +2087,8 @@ subroutine PressureForce_FV_init(Time, G, GV, US, param_file, diag, CS, ADp, SAL
                   "difference is only at bit level and due to a reordered summation.  Setting "//&
                   "dates before 20250201 recovers answers (Boussinesq mode) that interface "//&
                   "heights are modified before pressure force integrals are calculated.", &
-                  default=20230630, do_not_log=(.not.CS%tides))
+                  default=default_answer_date, do_not_log=(.not.CS%tides))
+  endif
   call get_param(param_file, mdl, "CALCULATE_SAL", CS%calculate_SAL, &
                  "If true, calculate self-attraction and loading.", default=CS%tides)
   if (CS%calculate_SAL) &

--- a/src/core/MOM_PressureForce_FV.F90
+++ b/src/core/MOM_PressureForce_FV.F90
@@ -2131,7 +2131,7 @@ subroutine PressureForce_FV_init(Time, G, GV, US, param_file, diag, CS, ADp, SAL
                  "If true and MASS_WEIGHT_IN_PRESSURE_GRADIENT is true, use mass weighting when "//&
                  "interpolating T/S for integrals near the top of the water column in FV "//&
                  "pressure gradient calculations. ", &
-                 default=.false.) !### Change Default to MASS_WEIGHT_IN_PRESSURE_GRADIENT?
+                 default=useMassWghtInterp)
   call get_param(param_file, mdl, "MASS_WEIGHT_IN_PGF_NONBOUS_BUG", MassWghtInterp_NonBous_bug, &
                  "If true, use a masking bug in non-Boussinesq calculations with mass weighting "//&
                  "when interpolating T/S for integrals near the bathymetry in FV pressure "//&

--- a/src/core/MOM_barotropic.F90
+++ b/src/core/MOM_barotropic.F90
@@ -5526,7 +5526,7 @@ subroutine barotropic_init(u, v, h, Time, G, GV, US, param_file, diag, CS, &
 
   call get_param(param_file, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
                  default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
-  call get_param(param_file, mdl, "VISC_REM_BUG", visc_rem_bug, default=enable_bugs, do_not_log=.true.)
+  call get_param(param_file, mdl, "VISC_REM_BUG", visc_rem_bug, default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "VISC_REM_BT_WEIGHT_BUG", CS%wt_uv_bug, &
                  "If true, recover a bug in barotropic solver that uses an unnormalized weight "//&
                  "function for vertical averages of baroclinic velocity and forcing. Default "//&

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -1488,7 +1488,7 @@ subroutine initialize_dyn_split_RK2(u, v, h, tv, uh, vh, eta, Time, G, GV, US, p
                  "If true, visc_rem_[uv] in split mode is incorrectly calculated or accounted "//&
                  "for in two places. This parameter controls the defaults of two individual "//&
                  "flags, VISC_REM_TIMESTEP_BUG in MOM_dynamics_split_RK2(b) and "//&
-                 "VISC_REM_BT_WEIGHT_BUG in MOM_barotropic.", default=enable_bugs)
+                 "VISC_REM_BT_WEIGHT_BUG in MOM_barotropic.", default=.false.)
   call get_param(param_file, mdl, "VISC_REM_TIMESTEP_BUG", CS%visc_rem_dt_bug, &
                  "If true, recover a bug that uses dt_pred rather than dt in "//&
                  "vertvisc_remnant() at the end of predictor stage for the following "//&

--- a/src/core/MOM_dynamics_split_RK2b.F90
+++ b/src/core/MOM_dynamics_split_RK2b.F90
@@ -1374,7 +1374,7 @@ subroutine initialize_dyn_split_RK2b(u, v, h, tv, uh, vh, eta, Time, G, GV, US, 
                  "If true, visc_rem_[uv] in split mode is incorrectly calculated or accounted "//&
                  "for in two places. This parameter controls the defaults of two individual "//&
                  "flags, VISC_REM_TIMESTEP_BUG in MOM_dynamics_split_RK2(b) and "//&
-                 "VISC_REM_BT_WEIGHT_BUG in MOM_barotropic.", default=enable_bugs)
+                 "VISC_REM_BT_WEIGHT_BUG in MOM_barotropic.", default=.false.)
   call get_param(param_file, mdl, "VISC_REM_TIMESTEP_BUG", CS%visc_rem_dt_bug, &
                  "If true, recover a bug that uses dt_pred rather than dt in "//&
                  "vertvisc_remnant() at the end of predictor stage for the following "//&

--- a/src/core/MOM_dynamics_unsplit.F90
+++ b/src/core/MOM_dynamics_unsplit.F90
@@ -634,9 +634,6 @@ subroutine initialize_dyn_unsplit(u, v, h, tv, Time, G, GV, US, param_file, diag
   character(len=48) :: flux_units
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  logical :: use_correct_dt_visc
-  logical :: test_value  ! This is used to determine whether a logical parameter is being set explicitly.
-  logical :: explicit_bug, explicit_fix ! These indicate which parameters are set explicitly.
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = GV%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -655,33 +652,6 @@ subroutine initialize_dyn_unsplit(u, v, h, tv, Time, G, GV, US, param_file, diag
   call log_version(param_file, mdl, version, "")
 
   call get_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", CS%dt_visc_bug, &
-                 "If false, use the correct timestep in the viscous terms applied in the first "//&
-                 "predictor step with the unsplit time stepping scheme, and in the calculation "//&
-                 "of the turbulent mixed layer properties for viscosity with unsplit or "//&
-                 "unsplit_RK2.  If true, an older incorrect value is used.", &
-                 default=.false., do_not_log=.true.)
-  ! This is used to test whether UNSPLIT_DT_VISC_BUG is being actively set.
-  call get_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", test_value, default=.true., do_not_log=.true.)
-  explicit_bug = CS%dt_visc_bug .eqv. test_value
-  call get_param(param_file, mdl, "FIX_UNSPLIT_DT_VISC_BUG", use_correct_dt_visc, &
-                 "If true, use the correct timestep in the viscous terms applied in the first "//&
-                 "predictor step with the unsplit time stepping scheme, and in the calculation "//&
-                 "of the turbulent mixed layer properties for viscosity with unsplit or "//&
-                 "unsplit_RK2.", default=.true., do_not_log=.true.)
-  call get_param(param_file, mdl, "FIX_UNSPLIT_DT_VISC_BUG", test_value, default=.false., do_not_log=.true.)
-  explicit_fix = use_correct_dt_visc .eqv. test_value
-
-  if (explicit_bug .and. explicit_fix .and. (use_correct_dt_visc .eqv. CS%dt_visc_bug)) then
-    ! UNSPLIT_DT_VISC_BUG is being explicitly set, and should not be changed.
-    call MOM_error(FATAL, "UNSPLIT_DT_VISC_BUG and FIX_UNSPLIT_DT_VISC_BUG are both being set "//&
-                   "with inconsistent values.  FIX_UNSPLIT_DT_VISC_BUG is an obsolete "//&
-                   "parameter and should be removed.")
-  elseif (explicit_fix) then
-    call MOM_error(WARNING, "FIX_UNSPLIT_DT_VISC_BUG is an obsolete parameter.  "//&
-                   "Use UNSPLIT_DT_VISC_BUG instead (noting that it has the opposite sense).")
-    CS%dt_visc_bug = .not.use_correct_dt_visc
-  endif
-  call log_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", CS%dt_visc_bug, &
                  "If false, use the correct timestep in the viscous terms applied in the first "//&
                  "predictor step with the unsplit time stepping scheme, and in the calculation "//&
                  "of the turbulent mixed layer properties for viscosity with unsplit or "//&

--- a/src/core/MOM_dynamics_unsplit_RK2.F90
+++ b/src/core/MOM_dynamics_unsplit_RK2.F90
@@ -581,9 +581,6 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, tv, Time, G, GV, US, param_file, 
   character(len=48) :: flux_units
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
-  logical :: use_correct_dt_visc
-  logical :: test_value  ! This is used to determine whether a logical parameter is being set explicitly.
-  logical :: explicit_bug, explicit_fix ! These indicate which parameters are set explicitly.
   integer :: isd, ied, jsd, jed, nz, IsdB, IedB, JsdB, JedB
   isd = G%isd ; ied = G%ied ; jsd = G%jsd ; jed = G%jed ; nz = GV%ke
   IsdB = G%IsdB ; IedB = G%IedB ; JsdB = G%JsdB ; JedB = G%JedB
@@ -618,33 +615,6 @@ subroutine initialize_dyn_unsplit_RK2(u, v, h, tv, Time, G, GV, US, param_file, 
                  units="nondim", default=0.0)
 
   call get_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", CS%dt_visc_bug, &
-                 "If false, use the correct timestep in the viscous terms applied in the first "//&
-                 "predictor step with the unsplit time stepping scheme, and in the calculation "//&
-                 "of the turbulent mixed layer properties for viscosity with unsplit or "//&
-                 "unsplit_RK2.  If true, an older incorrect value is used.", &
-                 default=.false., do_not_log=.true.)
-  ! This is used to test whether UNSPLIT_DT_VISC_BUG is being explicitly set.
-  call get_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", test_value, default=.true., do_not_log=.true.)
-  explicit_bug = CS%dt_visc_bug .eqv. test_value
-  call get_param(param_file, mdl, "FIX_UNSPLIT_DT_VISC_BUG", use_correct_dt_visc, &
-                 "If true, use the correct timestep in the viscous terms applied in the first "//&
-                 "predictor step with the unsplit time stepping scheme, and in the calculation "//&
-                 "of the turbulent mixed layer properties for viscosity with unsplit or "//&
-                 "unsplit_RK2.", default=.true., do_not_log=.true.)
-  call get_param(param_file, mdl, "FIX_UNSPLIT_DT_VISC_BUG", test_value, default=.false., do_not_log=.true.)
-  explicit_fix = use_correct_dt_visc .eqv. test_value
-
-  if (explicit_bug .and. explicit_fix .and. (use_correct_dt_visc .eqv. CS%dt_visc_bug)) then
-    ! UNSPLIT_DT_VISC_BUG is being explicitly set, and should not be changed.
-    call MOM_error(FATAL, "UNSPLIT_DT_VISC_BUG and FIX_UNSPLIT_DT_VISC_BUG are both being set "//&
-                   "with inconsistent values.  FIX_UNSPLIT_DT_VISC_BUG is an obsolete "//&
-                   "parameter and should be removed.")
-  elseif (explicit_fix) then
-    call MOM_error(WARNING, "FIX_UNSPLIT_DT_VISC_BUG is an obsolete parameter.  "//&
-                   "Use UNSPLIT_DT_VISC_BUG instead (noting that it has the opposite sense).")
-    CS%dt_visc_bug = .not.use_correct_dt_visc
-  endif
-  call log_param(param_file, mdl, "UNSPLIT_DT_VISC_BUG", CS%dt_visc_bug, &
                  "If false, use the correct timestep in the viscous terms applied in the first "//&
                  "predictor step with the unsplit time stepping scheme, and in the calculation "//&
                  "of the turbulent mixed layer properties for viscosity with unsplit or "//&

--- a/src/diagnostics/MOM_obsolete_params.F90
+++ b/src/diagnostics/MOM_obsolete_params.F90
@@ -108,9 +108,22 @@ subroutine find_obsolete_params(param_file)
   call obsolete_real(param_file, "MIN_Z_DIAG_INTERVAL")
   call obsolete_char(param_file, "Z_OUTPUT_GRID_FILE")
 
+  call obsolete_logical(param_file, "CFL_BASED_TRUNCATIONS", .true.)
+  call obsolete_logical(param_file, "KD_BACKGROUND_VIA_KDML_BUG", .false.)
+  call obsolete_logical(param_file, "USE_DIABATIC_TIME_BUG", .false.)
+
   call read_param(param_file, "INTERPOLATE_SPONGE_TIME_SPACE", test_logic)
   call obsolete_logical(param_file, "NEW_SPONGES", warning_val=test_logic, &
                         hint="Use INTERPOLATE_SPONGE_TIME_SPACE instead.")
+
+  test_logic = .true. ; call read_param(param_file, "BOUND_KH", test_logic)
+  call obsolete_logical(param_file, "BETTER_BOUND_KH", warning_val=test_logic, hint="Use BOUND_KH alone.")
+  test_logic = .true. ; call read_param(param_file, "BOUND_AH", test_logic)
+  call obsolete_logical(param_file, "BETTER_BOUND_AH", warning_val=test_logic, hint="Use BOUND_AH alone.")
+
+  test_logic = .false. ; call read_param(param_file, "UNSPLIT_DT_VISC_BUG", test_logic)
+  call obsolete_logical(param_file, "FIX_UNSPLIT_DT_VISC_BUG", warning_val=(.not.test_logic), &
+                        hint="Use UNSPLIT_DT_VISC_BUG instead, but with the reversed meaning.")
 
   call obsolete_logical(param_file, "SMOOTH_RI", hint="Instead use N_SMOOTH_RI.")
 

--- a/src/equation_of_state/MOM_EOS.F90
+++ b/src/equation_of_state/MOM_EOS.F90
@@ -179,7 +179,7 @@ character*(12), parameter :: EOS_NEMO_STRING   = "NEMO"   !< A string for specif
 character*(12), parameter :: EOS_ROQUET_RHO_STRING = "ROQUET_RHO"   !< A string for specifying the equation of state
 character*(12), parameter :: EOS_ROQUET_SPV_STRING = "ROQUET_SPV"   !< A string for specifying the equation of state
 character*(12), parameter :: EOS_JACKETT06_STRING = "JACKETT_06" !< A string for specifying the equation of state
-character*(12), parameter :: EOS_DEFAULT = EOS_WRIGHT_STRING !< The default equation of state
+character*(12), parameter :: EOS_DEFAULT = EOS_WRIGHT_FULL_STRING !< The default equation of state
 
 integer, parameter :: TFREEZE_LINEAR = 1  !< A named integer specifying a freezing point expression
 integer, parameter :: TFREEZE_MILLERO = 2 !< A named integer specifying a freezing point expression

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2669,7 +2669,7 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
   call get_param(param_file, mdl, "FRICTWORK_BUG", CS%FrictWork_bug, &
                  "If true, retain an answer-changing bug in calculating the FrictWork, "//&
                  "which cancels the h in thickness flux and the h at velocity point. This is"//&
-                 "not recommended.", default=enable_bugs)
+                 "not recommended.", default=.false.)
 
   call get_param(param_file, mdl, "USE_GME", CS%use_GME, &
                  "If true, use the GM+E backscatter scheme in association \n"//&

--- a/src/parameterizations/lateral/MOM_hor_visc.F90
+++ b/src/parameterizations/lateral/MOM_hor_visc.F90
@@ -2584,8 +2584,7 @@ subroutine hor_visc_init(Time, G, GV, US, param_file, diag, CS, ADp)
                  "biharmonic viscosity when no Laplacian viscosity is applied.  The default "//&
                  "is true for historical reasons, but this option probably should not be used "//&
                  "because it can contribute to numerical instabilities.", &
-                 default=.true., do_not_log=.not.((CS%better_bound_Kh).and.(CS%better_bound_Ah)))
-                 !### The default for BACKSCATTER_UNDERBOUND should be false.
+                 default=.false., do_not_log=.not.((CS%better_bound_Kh).and.(CS%better_bound_Ah)))
 
   call get_param(param_file, mdl, "SMAG_BI_CONST",Smag_bi_const, &
                  "The nondimensional biharmonic Smagorinsky constant, "//&

--- a/src/parameterizations/lateral/MOM_thickness_diffuse.F90
+++ b/src/parameterizations/lateral/MOM_thickness_diffuse.F90
@@ -2193,8 +2193,6 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
                                  ! as the vertical structure of thickness diffusivity.
                                  ! Used to determine if FULL_DEPTH_KHTH_MIN should be
                                  ! available.
-  logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
-                          ! recreate the bugs, or if false bugs are only used if actively selected.
   logical :: use_meke = .false. ! If true, use the MEKE formulation for the thickness diffusivity.
   integer :: default_answer_date ! The default setting for the various ANSWER_DATE flags.
   integer :: i, j
@@ -2355,14 +2353,12 @@ subroutine thickness_diffuse_init(Time, G, GV, US, param_file, diag, CDp, CS)
                  "MEKE_GM_SRC_ALT is true.  Values below 20240601 recover the answers from the "//&
                  "original implementation, while higher values use expressions that satisfy "//&
                  "rotational symmetry.", &
-                 default=20240101, do_not_log=.not.CS%GM_src_alt) ! ### Change default to default_answer_date.
-  call get_param(param_file, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
-                 default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
+                 default=default_answer_date, do_not_log=.not.CS%GM_src_alt)
   call get_param(param_file, mdl, "MEKE_GM_SRC_ALT_SLOPE_BUG", CS%MEKE_src_slope_bug, &
                  "If true, use a bug that limits the positive values, but not the negative values, "//&
                  "of the slopes used when MEKE_GM_SRC_ALT is true.  When this is true, it breaks "//&
                  "all of the symmetry rules that MOM6 is supposed to obey.", &
-                 default=enable_bugs, do_not_log=.not.CS%GM_src_alt)
+                 default=.false., do_not_log=.not.CS%GM_src_alt)
 
   call get_param(param_file, mdl, "MEKE_GEOMETRIC", CS%MEKE_GEOMETRIC, &
                  "If true, uses the GM coefficient formulation from the GEOMETRIC "//&

--- a/src/parameterizations/vertical/MOM_CVMix_KPP.F90
+++ b/src/parameterizations/vertical/MOM_CVMix_KPP.F90
@@ -523,7 +523,7 @@ logical function KPP_init(paramFile, G, GV, US, diag, Time, CS, passive)
                  "The vintage of the order of arithmetic in the CVMix KPP calculations.  Values "//&
                  "below 20240501 recover the answers from early in 2024, while higher values "//&
                  "use expressions that have been refactored for rotational symmetry.", &
-                 default=20240101) !### Change to: default=default_answer_date)
+                 default=default_answer_date)
 
   call closeParameterBlock(paramFile)
 

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -2473,8 +2473,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
                "The vintage of the order of arithmetic in the drag diffusivity calculations.  "//&
                "Values above 20250301 use less confusing expressions to set the bottom-drag "//&
                "generated diffusivity when USE_LOTW_BBL_DIFFUSIVITY is false. ", &
-               default=20250101, do_not_log=CS%use_LOTW_BBL_diffusivity.or.(CS%BBL_effic<=0.0))
-               !### Set default as default=default_answer_date, or use SET_DIFF_ANSWER_DATE.
+               default=CS%answer_date, do_not_log=CS%use_LOTW_BBL_diffusivity.or.(CS%BBL_effic<=0.0))
 
   CS%id_Kd_BBL = register_diag_field('ocean_model', 'Kd_BBL', diag%axesTi, Time, &
                  'Bottom Boundary Layer Diffusivity', 'm2 s-1', conversion=GV%HZ_T_to_m2_s)

--- a/src/parameterizations/vertical/MOM_set_diffusivity.F90
+++ b/src/parameterizations/vertical/MOM_set_diffusivity.F90
@@ -2468,8 +2468,7 @@ subroutine set_diffusivity_init(Time, G, GV, US, param_file, diag, CS, int_tide_
                "calculations.  Values below 20240630 recover the original answers, while "//&
                "higher values use more accurate expressions.  This only applies when "//&
                "USE_LOTW_BBL_DIFFUSIVITY is true.", &
-               default=20190101, do_not_log=.not.CS%use_LOTW_BBL_diffusivity)
-               !### Set default as default=default_answer_date, or use SET_DIFF_ANSWER_DATE.
+               default=default_answer_date, do_not_log=.not.CS%use_LOTW_BBL_diffusivity)
   call get_param(param_file, mdl, "DRAG_DIFFUSIVITY_ANSWER_DATE", CS%drag_diff_answer_date, &
                "The vintage of the order of arithmetic in the drag diffusivity calculations.  "//&
                "Values above 20250301 use less confusing expressions to set the bottom-drag "//&

--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -219,7 +219,7 @@ logical function neutral_diffusion_init(Time, G, GV, US, param_file, diag, EOS, 
                  "Values of 20240330 or below recover the answers from the original form of the "//&
                  "neutral diffusion code, while higher values use mathematically equivalent "//&
                  "expressions that recover rotational symmetry.", &
-                 default=20240101) !### Change this default later to default_answer_date.
+                 default=default_answer_date)
 
   ! Initialize and configure remapping
   if ( .not.CS%continuous_reconstruction ) then

--- a/src/tracer/MOM_tracer_Z_init.F90
+++ b/src/tracer/MOM_tracer_Z_init.F90
@@ -617,8 +617,6 @@ subroutine determine_temperature(temp, salt, R_tgt, EOS, p_ref, niter, k_start, 
   character(len=40)  :: mdl = "determine_temperature" ! This subroutine's name.
   logical :: domore(SZK_(GV)) ! Records which layers need additional iterations
   logical :: adjust_salt, fit_together, convergence_bug, do_any
-  logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
-                          ! recreate the bugs, or if false bugs are only used if actively selected.
   integer, dimension(2) :: EOSdom ! The i-computational domain for the equation of state
   integer :: i, j, k, is, ie, js, je, nz, itt
 
@@ -633,14 +631,12 @@ subroutine determine_temperature(temp, salt, R_tgt, EOS, p_ref, niter, k_start, 
                  "based on the ratio of the thermal and haline coefficients.  Otherwise try to "//&
                  "match the density by only adjusting temperatures within a maximum range before "//&
                  "revising estimates of the salinity.", default=.false., do_not_log=just_read)
-  call get_param(PF, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
-                 default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
   call get_param(PF, mdl, "DETERMINE_TEMP_CONVERGENCE_BUG", convergence_bug, &
                  "If true, use layout-dependent tests on the changes in temperature and salinity "//&
                  "to determine when the iterations have converged when DETERMINE_TEMP_ADJUST_T_AND_S "//&
                  "is false.  For realistic equations of state and the default values of the "//&
                  "various tolerances, this bug does not impact the solutions.", &
-                 default=enable_bugs, do_not_log=just_read)
+                 default=.false., do_not_log=just_read)
 
   call get_param(PF, mdl, "DETERMINE_TEMP_T_MIN", T_min, &
                  "The minimum temperature that can be found by determine_temperature.", &

--- a/src/tracer/MOM_tracer_hor_diff.F90
+++ b/src/tracer/MOM_tracer_hor_diff.F90
@@ -1641,8 +1641,6 @@ subroutine tracer_hor_diff_init(Time, G, GV, US, param_file, diag, EOS, diabatic
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
   character(len=40)  :: mdl = "MOM_tracer_hor_diff" ! This module's name.
-  logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
-                          ! recreate the bugs, or if false bugs are only used if actively selected.
   integer :: default_answer_date
 
   if (associated(CS)) then
@@ -1718,14 +1716,11 @@ subroutine tracer_hor_diff_init(Time, G, GV, US, param_file, diag, EOS, diabatic
                  "along-isopycnal mixed layer to interior mixing code, while higher values use "//&
                  "mathematically equivalent expressions that recover rotational symmetry "//&
                  "when DIFFUSE_ML_TO_INTERIOR is true.", &
-                 default=20240101, do_not_log=.not.CS%Diffuse_ML_interior)
-                 !### Change the default later to default_answer_date.
-  call get_param(param_file, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
-                 default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
+                 default=default_answer_date, do_not_log=.not.CS%Diffuse_ML_interior)
   call get_param(param_file, mdl, "HOR_DIFF_LIMIT_BUG", CS%limit_bug, &
                  "If true and the answer date is 20240330 or below, use a rotational symmetry "//&
                  "breaking bug when limiting the tracer properties in tracer_epipycnal_ML_diff.", &
-                 default=enable_bugs, do_not_log=((.not.CS%Diffuse_ML_interior).or.(CS%answer_date>=20240331)))
+                 default=.false., do_not_log=((.not.CS%Diffuse_ML_interior).or.(CS%answer_date>=20240331)))
   CS%ML_KhTR_scale = 1.0
   if (CS%Diffuse_ML_interior) then
     call get_param(param_file, mdl, "ML_KHTR_SCALE", CS%ML_KhTR_scale, &

--- a/src/user/Idealized_Hurricane.F90
+++ b/src/user/Idealized_Hurricane.F90
@@ -132,8 +132,6 @@ subroutine idealized_hurricane_wind_init(Time, G, US, param_file, CS)
   logical :: continuous_Cd  ! If true, use a continuous form for the simple drag coefficient as a
                  ! function of wind speed with the idealized hurricane.  When this is false, the
                  ! linear shape for the mid-range wind speeds is specified separately.
-  logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
-                          ! recreate the bugs, or if false bugs are only used if actively selected.
 
   ! This include declares and sets the variable "version".
 # include "version_variable.h"
@@ -240,13 +238,11 @@ subroutine idealized_hurricane_wind_init(Time, G, US, param_file, CS)
   call get_param(param_file, mdl, "IDL_HURR_SCM", CS%SCM_mode, &
                  "Single Column mode switch used in the SCM idealized hurricane wind profile.", &
                  default=.false.)
-  call get_param(param_file, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
-                 default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
   call get_param(param_file, mdl, "IDL_HURR_SCM_EDGE_TAPER_BUG", CS%edge_taper_bug, &
                  "If true and IDL_HURR_SCM is true, use a bug that does all of the tapering and "//&
                  "inflow angle calculations for radii between RAD_EDGE and RAD_AMBIENT as though "//&
                  "they were at RAD_EDGE.", &
-                 default=CS%SCM_mode.and.enable_bugs, do_not_log=.not.CS%SCM_mode)
+                 default=.false., do_not_log=.not.CS%SCM_mode)
   if (.not.CS%SCM_mode) CS%edge_taper_bug = .false.
   call get_param(param_file, mdl, "IDL_HURR_SCM_LOCY", CS%dy_from_center, &
                  "Y distance of station used in the SCM idealized hurricane wind profile.", &

--- a/src/user/Kelvin_initialization.F90
+++ b/src/user/Kelvin_initialization.F90
@@ -123,8 +123,7 @@ logical function register_Kelvin_OBC(param_file, CS, US, OBC_Reg)
                  "The timescale with which the inflowing open boundary velocities are nudged toward "//&
                  "their intended values with the Kelvin wave test case, or a negative value to keep "//&
                  "the value that is set when the OBC segments are initialized.", &
-                 units="s", default=1.0/(0.3*86400.), scale=US%s_to_T)
-                 !### Change the default nudging timescale to -1. or another value?
+                 units="s", default=-1.0, scale=US%s_to_T)
   call get_param(param_file, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
                  default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
   call get_param(param_file, mdl, "KELVIN_SET_OBC_INDEXING_BUGS", CS%indexing_bugs, &

--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -293,8 +293,6 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag)
   character*(7), parameter  :: COUPLER_STRING   = "COUPLER"
   character*(5), parameter  :: INPUT_STRING     = "INPUT"
   integer :: default_answer_date  ! The default setting for the various ANSWER_DATE flags
-  logical :: enable_bugs  ! If true, the defaults for recently added bug-fix flags are set to
-                          ! recreate the bugs, or if false bugs are only used if actively selected.
   logical :: use_waves
   logical :: StatisticalWaves
 
@@ -337,8 +335,7 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag)
                  "\t >= 20230101 - More robust expressions for Update_Stokes_Drift\n"//&
                  "\t >= 20230102 - More robust expressions for get_StokesSL_LiFoxKemper\n"//&
                  "\t >= 20230103 - More robust expressions for ust_2_u10_coare3p5", &
-                 default=20221231, do_not_log=.not.GV%Boussinesq)
-                 !### In due course change the default to default=default_answer_date)
+                 default=default_answer_date, do_not_log=.not.GV%Boussinesq)
   if (.not.GV%Boussinesq) CS%answer_date = max(CS%answer_date, 20230701)
 
   ! Langmuir number Options
@@ -538,12 +535,10 @@ subroutine MOM_wave_interface_init(time, G, GV, US, param_file, CS, diag)
   call get_param(param_file, mdl, "LA_MISALIGNMENT", CS%LA_Misalignment, &
          "Flag (logical) if using misalignment between shear and waves in LA", &
          default=.false.)
-  call get_param(param_file, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
-                 default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
   call get_param(param_file, mdl, "LA_MISALIGNMENT_BUG", CS%LA_misalign_bug, &
          "If true, use a code with a sign error when calculating the misalignment between "//&
          "the shear and waves when LA_MISALIGNMENT is true.", &
-         default=CS%LA_Misalignment.and.enable_bugs, do_not_log=.not.CS%LA_Misalignment)
+         default=.false., do_not_log=.not.CS%LA_Misalignment)
   call get_param(param_file, mdl, "MIN_LANGMUIR", CS%La_min,    &
          "A minimum value for all Langmuir numbers that is not physical, "//&
          "but is likely only encountered when the wind is very small and "//&

--- a/src/user/shelfwave_initialization.F90
+++ b/src/user/shelfwave_initialization.F90
@@ -81,7 +81,7 @@ function register_shelfwave_OBC(param_file, CS, G, US, OBC_Reg)
                  units="nondim", default=1.)
   call get_param(param_file, mdl, "SHELFWAVE_CORRECT_AMPLITUDE", CS%shelfwave_correct_amplitude, &
                  "If true, SHELFWAVE_AMPLITUDE gives the actual inflow velocity, rather than giving "//&
-                 "an overall scaling factor for the flow.", default=.false.)  !### Make the default .true.?
+                 "an overall scaling factor for the flow.", default=.true.)
   default_amp = 1.0 ; if (CS%shelfwave_correct_amplitude) default_amp = 0.1
   call get_param(param_file, mdl, "SHELFWAVE_AMPLITUDE", CS%my_amp, &
                  "Amplitude of the open boundary current inflows in the shelfwave configuration.", &


### PR DESCRIPTION
  This series of 3 commits updates the defaults for a total of 21 runtime parameters, and obsoletes another 7 runtime parameters, as agreed to in MOM6 consortium-wide meetings on July 29, 2024, December 16, 2024 and  June 2, 2025.

 The default equation of state is now `EQN_OF_STATE = "WRIGHT_FULL"`, in place of the buggy previous default of `"WRIGHT"`.

  The 8 answer date parameters `REGRIDDING_ANSWER_DATE`, `TIDES_ANSWER_DATE`, `WAVE_INTERFACE_ANSWER_DATE`, `MEKE_GM_SRC_ANSWER_DATE`, `NDIFF_ANSWER_DATE`, `KPP%ANSWER_DATE`, `HOR_DIFF_ANSWER_DATE` and `LOTW_BBL_ANSWER_DATE` all now take their default values from `DEFAULT_ANSWER_DATE`.

  The bug-retention parameters `MEKE_GM_SRC_ALT_SLOPE_BUG`, `HOR_DIFF_LIMIT_BUG`, `BACKSCATTER_UNDERBOUND`, `DETERMINE_TEMP_CONVERGENCE_BUG`, `LA_MISALIGNMENT_BUG`, `IDL_HURR_SCM_EDGE_TAPER_BUG`, `VISC_REM_BUG` and `FRICTWORK_BUG` are now false by default.

  With these changes, `MASS_WEIGHT_IN_PRESSURE_GRADIENT_TOP` now takes its default value from the setting for `MASS_WEIGHT_IN_PRESSURE_GRADIENT`.  Similarly, the default for `DRAG_DIFFUSIVITY_ANSWER_DATE` is now set to follow `SET_DIFF_ANSWER_DATE`. `KELVIN_WAVE_VEL_NUDGING_TIMESCALE` is now set to a negative value by default, forcing the user to provide a valid value at runtime. `SHELFWAVE_CORRECT_AMPLITUDE` now defaults to True.

  The parameters `BETTER_BOUND_KH`, `BETTER_BOUND_AH`, `USE_DIABATIC_TIME_BUG`, `FIX_UNSPLIT_DT_VISC_BUG`, `CFL_BASED_TRUNCATIONS` and `KD_BACKGROUND_VIA_KDML_BUG` have all been obsoleted and are no longer valid MOM6 runtime parameters.

  These code changes can change answers if any of the impacted parameters are taking their default values, but answers will not change if they are set explicitly. The easiest way to determine what parameters must now be set explicitly to retain existing answers is to run a configuration twice with versions of the model from before and after this PR, and to compare the MOM_parameter_doc.all files to determine which parameters have been changed by the changing defaults.  The 3rd of the 3 commits, which obsoletes several parameters, also has the effect of changing the order with which some of the retained parameters are logged in the MOM_parameter_doc.all files, so identifying which parameters need to be set explicitly to handle changes to their defaults is simpler if only the first two commits are considered.

  The specific commits in this PR include:

 - NOAA-GFDL/MOM6@5ac077fad +Obsoleted 7 parameters, including BETTER_BOUND_KH
 - NOAA-GFDL/MOM6@05311b535 *Update defaults for 6 parameters (VISC_REM_BUG, )
 - NOAA-GFDL/MOM6@62d74dfc1 *Update defaults for EQN_OF_STATE and 14 parameters