### PR TITLE
Fixes for flang in MOM_remapping.F90

### DIFF
--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -19,22 +19,22 @@ use PQM_functions, only : PQM_reconstruction, PQM_boundary_extrapolation_v1
 use MOM_hybgen_remap, only : hybgen_plm_coefs, hybgen_ppm_coefs, hybgen_weno_coefs
 
 use Recon1d_type, only : Recon1d
-use Recon1d_PCM, only : PCM
-use Recon1d_PLM_CW, only : PLM_CW
-use Recon1d_PLM_hybgen, only : PLM_hybgen
-use Recon1d_PLM_CWK, only : PLM_CWK
-use Recon1d_MPLM_CWK, only : MPLM_CWK
-use Recon1d_EMPLM_CWK, only : EMPLM_CWK
-use Recon1d_MPLM_WA, only : MPLM_WA
-use Recon1d_EMPLM_WA, only : EMPLM_WA
-use Recon1d_MPLM_WA_poly, only : MPLM_WA_poly
-use Recon1d_EMPLM_WA_poly, only : EMPLM_WA_poly
-use Recon1d_PPM_CW, only : PPM_CW
-use Recon1d_PPM_hybgen, only : PPM_hybgen
-use Recon1d_PPM_CWK, only : PPM_CWK
-use Recon1d_EPPM_CWK, only : EPPM_CWK
-use Recon1d_PPM_H4_2019, only : PPM_H4_2019
-use Recon1d_PPM_H4_2018, only : PPM_H4_2018
+use Recon1d_PCM, only : PCM_t => PCM
+use Recon1d_PLM_CW, only : PLM_CW_t => PLM_CW
+use Recon1d_PLM_hybgen, only : PLM_hybgen_t => PLM_hybgen
+use Recon1d_PLM_CWK, only : PLM_CWK_t => PLM_CWK
+use Recon1d_MPLM_CWK, only : MPLM_CWK_t => MPLM_CWK
+use Recon1d_EMPLM_CWK, only : EMPLM_CWK_t => EMPLM_CWK
+use Recon1d_MPLM_WA, only : MPLM_WA_t => MPLM_WA
+use Recon1d_EMPLM_WA, only : EMPLM_WA_t => EMPLM_WA
+use Recon1d_MPLM_WA_poly, only : MPLM_WA_poly_t => MPLM_WA_poly
+use Recon1d_EMPLM_WA_poly, only : EMPLM_WA_poly_t => EMPLM_WA_poly
+use Recon1d_PPM_CW, only : PPM_CW_t => PPM_CW
+use Recon1d_PPM_hybgen, only : PPM_hybgen_t => PPM_hybgen
+use Recon1d_PPM_CWK, only : PPM_CWK_t => PPM_CWK
+use Recon1d_EPPM_CWK, only : EPPM_CWK_t => EPPM_CWK
+use Recon1d_PPM_H4_2019, only : PPM_H4_2019_t => PPM_H4_2019
+use Recon1d_PPM_H4_2018, only : PPM_H4_2018_t => PPM_H4_2018
 
 implicit none ; private
 
@@ -1745,52 +1745,52 @@ subroutine setReconstructionType(string,CS)
       CS%remapping_scheme = REMAPPING_PQM_IH6IH5
       degree = 4
     case ("C_PCM")
-      allocate( PCM :: CS%reconstruction )
+      allocate( PCM_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PLM_CW")
-      allocate( PLM_CW :: CS%reconstruction )
+      allocate( PLM_CW_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PLM_HYBGEN")
-      allocate( PLM_hybgen :: CS%reconstruction )
+      allocate( PLM_hybgen_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_MPLM_WA")
-      allocate( MPLM_WA :: CS%reconstruction )
+      allocate( MPLM_WA_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_EMPLM_WA")
-      allocate( EMPLM_WA :: CS%reconstruction )
+      allocate( EMPLM_WA_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_MPLM_WA_POLY")
-      allocate( MPLM_WA_poly :: CS%reconstruction )
+      allocate( MPLM_WA_poly_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_EMPLM_WA_POLY")
-      allocate( EMPLM_WA_poly :: CS%reconstruction )
+      allocate( EMPLM_WA_poly_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PLM_CWK")
-      allocate( PLM_CWK :: CS%reconstruction )
+      allocate( PLM_CWK_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_MPLM_CWK")
-      allocate( MPLM_CWK :: CS%reconstruction )
+      allocate( MPLM_CWK_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_EMPLM_CWK")
-      allocate( EMPLM_CWK :: CS%reconstruction )
+      allocate( EMPLM_CWK_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PPM_CW")
-      allocate( PPM_CW :: CS%reconstruction )
+      allocate( PPM_CW_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PPM_HYBGEN")
-      allocate( PPM_hybgen :: CS%reconstruction )
+      allocate( PPM_hybgen_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PPM_CWK")
-      allocate( PPM_CWK :: CS%reconstruction )
+      allocate( PPM_CWK_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_EPPM_CWK")
-      allocate( EPPM_CWK :: CS%reconstruction )
+      allocate( EPPM_CWK_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PPM_H4_2019")
-      allocate( PPM_H4_2019 :: CS%reconstruction )
+      allocate( PPM_H4_2019_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PPM_H4_2018")
-      allocate( PPM_H4_2018 :: CS%reconstruction )
+      allocate( PPM_H4_2018_t :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case default
       call MOM_error(FATAL, "setReconstructionType: "//&
@@ -2095,22 +2095,22 @@ logical function remapping_unit_tests(verbose, num_comp_samp)
   integer :: om4 ! Loop parameter, 0 or 1
   integer :: ntests ! Number of iterations when brute force testing
   character(len=4) :: om4_tag ! Generated label
-  type(PCM) :: PCM
-  type(PLM_CW) :: PLM_CW
-  type(PLM_hybgen) :: PLM_hybgen
-  type(MPLM_WA) :: MPLM_WA
-  type(EMPLM_WA) :: EMPLM_WA
-  type(MPLM_WA_poly) :: MPLM_WA_poly
-  type(EMPLM_WA_poly) :: EMPLM_WA_poly
-  type(PLM_CWK) :: PLM_CWK
-  type(MPLM_CWK) :: MPLM_CWK
-  type(EMPLM_CWK) :: EMPLM_CWK
-  type(PPM_H4_2019) :: PPM_H4_2019
-  type(PPM_H4_2018) :: PPM_H4_2018
-  type(PPM_CW) :: PPM_CW
-  type(PPM_hybgen) :: PPM_hybgen
-  type(PPM_CWK) :: PPM_CWK
-  type(EPPM_CWK) :: EPPM_CWK
+  type(PCM_t) :: PCM
+  type(PLM_CW_t) :: PLM_CW
+  type(PLM_hybgen_t) :: PLM_hybgen
+  type(MPLM_WA_t) :: MPLM_WA
+  type(EMPLM_WA_t) :: EMPLM_WA
+  type(MPLM_WA_poly_t) :: MPLM_WA_poly
+  type(EMPLM_WA_poly_t) :: EMPLM_WA_poly
+  type(PLM_CWK_t) :: PLM_CWK
+  type(MPLM_CWK_t) :: MPLM_CWK
+  type(EMPLM_CWK_t) :: EMPLM_CWK
+  type(PPM_H4_2019_t) :: PPM_H4_2019
+  type(PPM_H4_2018_t) :: PPM_H4_2018
+  type(PPM_CW_t) :: PPM_CW
+  type(PPM_hybgen_t) :: PPM_hybgen
+  type(PPM_CWK_t) :: PPM_CWK
+  type(EPPM_CWK_t) :: EPPM_CWK
 
   call test%set( verbose=verbose ) ! Sets the verbosity flag in test
 ! call test%set( stop_instantly=.true. ) ! While debugging

--- a/src/ALE/MOM_remapping.F90
+++ b/src/ALE/MOM_remapping.F90
@@ -19,22 +19,22 @@ use PQM_functions, only : PQM_reconstruction, PQM_boundary_extrapolation_v1
 use MOM_hybgen_remap, only : hybgen_plm_coefs, hybgen_ppm_coefs, hybgen_weno_coefs
 
 use Recon1d_type, only : Recon1d
-use Recon1d_PCM, only : PCM_t => PCM
-use Recon1d_PLM_CW, only : PLM_CW_t => PLM_CW
-use Recon1d_PLM_hybgen, only : PLM_hybgen_t => PLM_hybgen
-use Recon1d_PLM_CWK, only : PLM_CWK_t => PLM_CWK
-use Recon1d_MPLM_CWK, only : MPLM_CWK_t => MPLM_CWK
-use Recon1d_EMPLM_CWK, only : EMPLM_CWK_t => EMPLM_CWK
-use Recon1d_MPLM_WA, only : MPLM_WA_t => MPLM_WA
-use Recon1d_EMPLM_WA, only : EMPLM_WA_t => EMPLM_WA
-use Recon1d_MPLM_WA_poly, only : MPLM_WA_poly_t => MPLM_WA_poly
-use Recon1d_EMPLM_WA_poly, only : EMPLM_WA_poly_t => EMPLM_WA_poly
-use Recon1d_PPM_CW, only : PPM_CW_t => PPM_CW
-use Recon1d_PPM_hybgen, only : PPM_hybgen_t => PPM_hybgen
-use Recon1d_PPM_CWK, only : PPM_CWK_t => PPM_CWK
-use Recon1d_EPPM_CWK, only : EPPM_CWK_t => EPPM_CWK
-use Recon1d_PPM_H4_2019, only : PPM_H4_2019_t => PPM_H4_2019
-use Recon1d_PPM_H4_2018, only : PPM_H4_2018_t => PPM_H4_2018
+use Recon1d_PCM, only : PCM
+use Recon1d_PLM_CW, only : PLM_CW
+use Recon1d_PLM_hybgen, only : PLM_hybgen
+use Recon1d_PLM_CWK, only : PLM_CWK
+use Recon1d_MPLM_CWK, only : MPLM_CWK
+use Recon1d_EMPLM_CWK, only : EMPLM_CWK
+use Recon1d_MPLM_WA, only : MPLM_WA
+use Recon1d_EMPLM_WA, only : EMPLM_WA
+use Recon1d_MPLM_WA_poly, only : MPLM_WA_poly
+use Recon1d_EMPLM_WA_poly, only : EMPLM_WA_poly
+use Recon1d_PPM_CW, only : PPM_CW
+use Recon1d_PPM_hybgen, only : PPM_hybgen
+use Recon1d_PPM_CWK, only : PPM_CWK
+use Recon1d_EPPM_CWK, only : EPPM_CWK
+use Recon1d_PPM_H4_2019, only : PPM_H4_2019
+use Recon1d_PPM_H4_2018, only : PPM_H4_2018
 
 implicit none ; private
 
@@ -1745,52 +1745,52 @@ subroutine setReconstructionType(string,CS)
       CS%remapping_scheme = REMAPPING_PQM_IH6IH5
       degree = 4
     case ("C_PCM")
-      allocate( PCM_t :: CS%reconstruction )
+      allocate( PCM :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PLM_CW")
-      allocate( PLM_CW_t :: CS%reconstruction )
+      allocate( PLM_CW :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PLM_HYBGEN")
-      allocate( PLM_hybgen_t :: CS%reconstruction )
+      allocate( PLM_hybgen :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_MPLM_WA")
-      allocate( MPLM_WA_t :: CS%reconstruction )
+      allocate( MPLM_WA :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_EMPLM_WA")
-      allocate( EMPLM_WA_t :: CS%reconstruction )
+      allocate( EMPLM_WA :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_MPLM_WA_POLY")
-      allocate( MPLM_WA_poly_t :: CS%reconstruction )
+      allocate( MPLM_WA_poly :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_EMPLM_WA_POLY")
-      allocate( EMPLM_WA_poly_t :: CS%reconstruction )
+      allocate( EMPLM_WA_poly :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PLM_CWK")
-      allocate( PLM_CWK_t :: CS%reconstruction )
+      allocate( PLM_CWK :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_MPLM_CWK")
-      allocate( MPLM_CWK_t :: CS%reconstruction )
+      allocate( MPLM_CWK :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_EMPLM_CWK")
-      allocate( EMPLM_CWK_t :: CS%reconstruction )
+      allocate( EMPLM_CWK :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PPM_CW")
-      allocate( PPM_CW_t :: CS%reconstruction )
+      allocate( PPM_CW :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PPM_HYBGEN")
-      allocate( PPM_hybgen_t :: CS%reconstruction )
+      allocate( PPM_hybgen :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PPM_CWK")
-      allocate( PPM_CWK_t :: CS%reconstruction )
+      allocate( PPM_CWK :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_EPPM_CWK")
-      allocate( EPPM_CWK_t :: CS%reconstruction )
+      allocate( EPPM_CWK :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PPM_H4_2019")
-      allocate( PPM_H4_2019_t :: CS%reconstruction )
+      allocate( PPM_H4_2019 :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case ("C_PPM_H4_2018")
-      allocate( PPM_H4_2018_t :: CS%reconstruction )
+      allocate( PPM_H4_2018 :: CS%reconstruction )
       CS%remapping_scheme = REMAPPING_VIA_CLASS
     case default
       call MOM_error(FATAL, "setReconstructionType: "//&
@@ -2095,22 +2095,22 @@ logical function remapping_unit_tests(verbose, num_comp_samp)
   integer :: om4 ! Loop parameter, 0 or 1
   integer :: ntests ! Number of iterations when brute force testing
   character(len=4) :: om4_tag ! Generated label
-  type(PCM_t) :: PCM
-  type(PLM_CW_t) :: PLM_CW
-  type(PLM_hybgen_t) :: PLM_hybgen
-  type(MPLM_WA_t) :: MPLM_WA
-  type(EMPLM_WA_t) :: EMPLM_WA
-  type(MPLM_WA_poly_t) :: MPLM_WA_poly
-  type(EMPLM_WA_poly_t) :: EMPLM_WA_poly
-  type(PLM_CWK_t) :: PLM_CWK
-  type(MPLM_CWK_t) :: MPLM_CWK
-  type(EMPLM_CWK_t) :: EMPLM_CWK
-  type(PPM_H4_2019_t) :: PPM_H4_2019
-  type(PPM_H4_2018_t) :: PPM_H4_2018
-  type(PPM_CW_t) :: PPM_CW
-  type(PPM_hybgen_t) :: PPM_hybgen
-  type(PPM_CWK_t) :: PPM_CWK
-  type(EPPM_CWK_t) :: EPPM_CWK
+  type(PCM) :: PCM_instance
+  type(PLM_CW) :: PLM_CW_instance
+  type(PLM_hybgen) :: PLM_hybgen_instance
+  type(MPLM_WA) :: MPLM_WA_instance
+  type(EMPLM_WA) :: EMPLM_WA_instance
+  type(MPLM_WA_poly) :: MPLM_WA_poly_instance
+  type(EMPLM_WA_poly) :: EMPLM_WA_poly_instance
+  type(PLM_CWK) :: PLM_CWK_instance
+  type(MPLM_CWK) :: MPLM_CWK_instance
+  type(EMPLM_CWK) :: EMPLM_CWK_instance
+  type(PPM_H4_2019) :: PPM_H4_2019_instance
+  type(PPM_H4_2018) :: PPM_H4_2018_instance
+  type(PPM_CW) :: PPM_CW_instance
+  type(PPM_hybgen) :: PPM_hybgen_instance
+  type(PPM_CWK) :: PPM_CWK_instance
+  type(EPPM_CWK) :: EPPM_CWK_instance
 
   call test%set( verbose=verbose ) ! Sets the verbosity flag in test
 ! call test%set( stop_instantly=.true. ) ! While debugging
@@ -2724,22 +2724,22 @@ logical function remapping_unit_tests(verbose, num_comp_samp)
                      3, (/0.,0.,0./), (/0.,0.,0./) )
 
   if (verbose) write(test%stdout,*) '- - - - - - - - - - Recon1d PCM tests  - - - - - - - - -'
-  call test%test( PCM%unit_tests(verbose, test%stdout, test%stderr), 'PCM unit test')
-  call test%test( MPLM_WA%unit_tests(verbose, test%stdout, test%stderr), 'MPLM_WA unit test')
-  call test%test( EMPLM_WA%unit_tests(verbose, test%stdout, test%stderr), 'EMPLM_WA unit test')
-  call test%test( MPLM_WA_poly%unit_tests(verbose, test%stdout, test%stderr), 'MPLM_WA_poly unit test')
-  call test%test( EMPLM_WA_poly%unit_tests(verbose, test%stdout, test%stderr), 'EMPLM_WA_poly unit test')
-  call test%test( PLM_hybgen%unit_tests(verbose, test%stdout, test%stderr), 'PLM_hybgen unit test')
-  call test%test( PLM_CW%unit_tests(verbose, test%stdout, test%stderr), 'PLM_CW unit test')
-  call test%test( PLM_CWK%unit_tests(verbose, test%stdout, test%stderr), 'PLM_CWK unit test')
-  call test%test( MPLM_CWK%unit_tests(verbose, test%stdout, test%stderr), 'MPLM_CWK unit test')
-  call test%test( EMPLM_CWK%unit_tests(verbose, test%stdout, test%stderr), 'EMPLM_CWK unit test')
-  call test%test( PPM_H4_2019%unit_tests(verbose, test%stdout, test%stderr), 'PPM_H4_2019 unit test')
-  call test%test( PPM_H4_2018%unit_tests(verbose, test%stdout, test%stderr), 'PPM_H4_2018 unit test')
-  call test%test( PPM_hybgen%unit_tests(verbose, test%stdout, test%stderr), 'PPM_hybgen unit test')
-  call test%test( PPM_CW%unit_tests(verbose, test%stdout, test%stderr), 'PPM_CW unit test')
-  call test%test( PPM_CWK%unit_tests(verbose, test%stdout, test%stderr), 'PPM_CWK unit test')
-  call test%test( EPPM_CWK%unit_tests(verbose, test%stdout, test%stderr), 'EPPM_CWK unit test')
+  call test%test( PCM_instance%unit_tests(verbose, test%stdout, test%stderr), 'PCM unit test')
+  call test%test( MPLM_WA_instance%unit_tests(verbose, test%stdout, test%stderr), 'MPLM_WA unit test')
+  call test%test( EMPLM_WA_instance%unit_tests(verbose, test%stdout, test%stderr), 'EMPLM_WA unit test')
+  call test%test( MPLM_WA_poly_instance%unit_tests(verbose, test%stdout, test%stderr), 'MPLM_WA_poly unit test')
+  call test%test( EMPLM_WA_poly_instance%unit_tests(verbose, test%stdout, test%stderr), 'EMPLM_WA_poly unit test')
+  call test%test( PLM_hybgen_instance%unit_tests(verbose, test%stdout, test%stderr), 'PLM_hybgen unit test')
+  call test%test( PLM_CW_instance%unit_tests(verbose, test%stdout, test%stderr), 'PLM_CW unit test')
+  call test%test( PLM_CWK_instance%unit_tests(verbose, test%stdout, test%stderr), 'PLM_CWK unit test')
+  call test%test( MPLM_CWK_instance%unit_tests(verbose, test%stdout, test%stderr), 'MPLM_CWK unit test')
+  call test%test( EMPLM_CWK_instance%unit_tests(verbose, test%stdout, test%stderr), 'EMPLM_CWK unit test')
+  call test%test( PPM_H4_2019_instance%unit_tests(verbose, test%stdout, test%stderr), 'PPM_H4_2019 unit test')
+  call test%test( PPM_H4_2018_instance%unit_tests(verbose, test%stdout, test%stderr), 'PPM_H4_2018 unit test')
+  call test%test( PPM_hybgen_instance%unit_tests(verbose, test%stdout, test%stderr), 'PPM_hybgen unit test')
+  call test%test( PPM_CW_instance%unit_tests(verbose, test%stdout, test%stderr), 'PPM_CW unit test')
+  call test%test( PPM_CWK_instance%unit_tests(verbose, test%stdout, test%stderr), 'PPM_CWK unit test')
+  call test%test( EPPM_CWK_instance%unit_tests(verbose, test%stdout, test%stderr), 'EPPM_CWK unit test')
 
   ! Randomized, brute force tests
   ntests = 3000


### PR DESCRIPTION
Closes #1689 

This PR fixes #1689 by renaming the instance of a type. Fortran does not allow (or is unhappy with):
```fortran
type(PCM) :: PCM
```
Both `ifort`/`ifx` and GNU seem to allow this, but stricter compilers like `nagfor` and `flang` do not.

So we do:
```fortran
type(PCM) :: PCM_instance
```
and then rename the variable use below, e.g.:
```fortran
  call test%test( PCM_instance%unit_tests(verbose, test%stdout, test%stderr), 'PCM unit test')
```

NOTE: GEOS does not build *all* of MOM6, for example, the NUOPC code, but we do a good chunk. This was the only error Flang flagged.