### PR TITLE
Update link for available diagnostics example

### DIFF
--- a/src/framework/_Diagnostics.dox
+++ b/src/framework/_Diagnostics.dox
@@ -135,7 +135,7 @@ An arbitrary number of lines, one per diagnostic field:
 
 The list of available diagnostics is dependent on the particular configuration of the model.
 For this reason the model writes a record of the available diagnostic fields at run-time into a file "available_diags.*".
-See, for example, [available_diags.000000](https://github.com/NOAA-GFDL/MOM6-examples/blob/dev/master/ocean_only/global_ALE/z/available_diags.000000) for the global_ALE z-coordinate ocean-only test case.
+See, for example, [available_diags.000000](https://github.com/NOAA-GFDL/MOM6-examples/blob/dev/gfdl/ocean_only/global_ALE/z/available_diags.000000) for the global_ALE z-coordinate ocean-only test case.
 
 Diagnostic fields in the module "ocean_model" refer to the native variables or diagnostics in the native grid.
 Since the model can be run in arbitrary coordinates, say in hybrid-coordinate mode, then native-space diagnostics can be potentially confusing.


### PR DESCRIPTION
Very minor but this was a typo I think?

[This address](https://github.com/NOAA-GFDL/MOM6-examples/blob/dev/master/ocean_only/global_ALE/z/available_diags.000000) gives me a 404 error [whereas this](https://github.com/NOAA-GFDL/MOM6-examples/blob/dev/gfdl/ocean_only/global_ALE/z/available_diags.000000) does not.

Found this because I was writing some training notes: https://decoding-access-om3.readthedocs.io/decoding_mom6/#specifying-model-outputs-via-diag_table-or-make_diag_table

--

Not quite sure what the protocol is for fixing trivial bits of the docs? Feel free to direct me accordingly, or close this as appropriate etc.