### PR TITLE
Add ability to smoothly turn off the MLE scheme for deep mixed layers

### DIFF
--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -68,6 +68,11 @@ type, public :: mixedlayer_restrat_CS ; private
                                    !! the mixed-layer [nondim].
   real    :: MLE_MLD_stretch       !< A scaling coefficient for stretching/shrinking the MLD used in
                                    !! the MLE scheme [nondim]. This simply multiplies MLD wherever used.
+  real    :: MLE_TAPER_FN_DEPTH    !< The mixed layer depth in the FFH and Bodner schemes can be tapered.
+                                   !! H is replaced by H / (1 + (H/H0)**P) where H0 is MLE_TAPER_FN_DEPTH.
+                                   !! [Z ~> m]
+  integer :: MLE_TAPER_FN_POWER    !< The mixed layer depth in the FFH and Bodner schemes can be tapered.
+                                   !! H is replaced by H / (1 + (H/H0)**P) where P is MLE_TAPER_FN_POWER.
 
   ! The following parameters are used in the Bodner et al., 2023, parameterization
   logical :: use_Bodner = .false.  !< If true, use the Bodner et al., 2023, parameterization.
@@ -324,6 +329,13 @@ subroutine mixedlayer_restrat_OM4(h, uhtr, vhtr, tv, forces, dt, h_MLD, VarMix, 
   else
     call MOM_error(FATAL, "mixedlayer_restrat_OM4: "// &
          "No MLD to use for MLE parameterization.")
+  endif
+
+  ! Smoothly turn off the scheme by reducing the MLD when the MLD is greater than CS%MLE_TAPER_FN_DEPTH
+  if ((CS%MLE_TAPER_FN_POWER > 0) .and. (CS%MLE_TAPER_FN_DEPTH > 0.)) then
+    do j=js-1,je+1 ; do i=is-1,ie+1
+      MLD_fast(i,j) = MLD_fast(i,j) / (1. + (MLD_fast(i,j)/CS%MLE_TAPER_FN_DEPTH)**CS%MLE_TAPER_FN_POWER)
+    enddo ; enddo
   endif
 
   ! Apply time filter (to remove diurnal cycle)
@@ -933,6 +945,13 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
     CS%MLD_filtered(i,j) = little_h(i,j)
   enddo ; enddo
 
+  ! Smoothly turn off the scheme by reducing the MLD when the MLD is greater than CS%MLE_TAPER_FN_DEPTH
+  if ((CS%MLE_TAPER_FN_POWER > 0) .and. (CS%MLE_TAPER_FN_DEPTH > 0.)) then
+    do j=js-1,je+1 ; do i=is-1,ie+1
+      little_h(i,j) = little_h(i,j) / (1. + (little_h(i,j)/CS%MLE_TAPER_FN_DEPTH)**CS%MLE_TAPER_FN_POWER)
+    enddo ; enddo
+  endif
+
   ! Calculate "big H", representative of the mixed layer depth, used in B22 formula (eq 27).
   if (CS%MLD_grid) then
     do j=js-1,je+1 ; do i=is-1,ie+1
@@ -951,6 +970,14 @@ subroutine mixedlayer_restrat_Bodner(CS, G, GV, US, h, uhtr, vhtr, tv, forces, d
                             CS%MLD_growing_Tfilt, CS%MLD_decaying_Tfilt, dt)
     enddo ; enddo
   endif
+
+  ! Smoothly turn off the scheme by reducing the MLD when the MLD is greater than CS%MLE_TAPER_FN_DEPTH
+  if ((CS%MLE_TAPER_FN_POWER > 0) .and. (CS%MLE_TAPER_FN_DEPTH > 0.)) then
+    do j=js-1,je+1 ; do i=is-1,ie+1
+      big_H(i,j) = big_H(i,j) / (1. + (big_H(i,j)/CS%MLE_TAPER_FN_DEPTH)**CS%MLE_TAPER_FN_POWER)
+    enddo ; enddo
+  endif
+
   do j=js-1,je+1 ; do i=is-1,ie+1
     CS%MLD_filtered_slow(i,j) = big_H(i,j)
   enddo ; enddo
@@ -1713,6 +1740,8 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
   CS%fl_from_file = .false.
   CS%MLD_grid = .false.
   CS%Cr_grid = .false.
+  CS%MLE_TAPER_FN_POWER = 0
+  CS%MLE_TAPER_FN_DEPTH = 0.0
 
   call get_param(param_file, mdl, "DEBUG", CS%debug, default=.false., do_not_log=.true.)
   call get_param(param_file, mdl, "DEFAULT_ANSWER_DATE", default_answer_date, &
@@ -1724,6 +1753,16 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
   call get_param(param_file, mdl, "USE_STANLEY_ML", CS%use_Stanley_ML, &
                  "If true, turn on Stanley SGS T variance parameterization "// &
                  "in ML restrat code.", default=.false.)
+  call get_param(param_file, mdl, "MLE_TAPER_FN_DEPTH", CS%MLE_TAPER_FN_DEPTH, &
+                 "Mixed layer (and mixing-layer) depths in the MLE restratification "//&
+                 "schemes are replaced by H / (1 + (H/H0)**P) when "//&
+                 "P=MLE_TAPER_FN_POWER > 0 and H0=MLE_TAPER_FN_DEPTH > 0.", &
+                 default=0., scale=US%m_to_Z)
+  call get_param(param_file, mdl, "MLE_TAPER_FN_POWER", CS%MLE_TAPER_FN_POWER, &
+                 "The power of H/H0 in the MLE mixed-layer depth tapering. "//&
+                 "Any positive integer may be used, but even integers are more "//&
+                 "efficient to calculate. Very large values may lead to numerical "//&
+                 "instabilities.", default=0)
   if (CS%use_Stanley_ML .and. .not.stoch_eos) then
     call MOM_error(FATAL, "mixedlayer_restrat_init: USE_STANLEY_ML requires STOCH_EOS")
   endif

--- a/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
+++ b/src/parameterizations/lateral/MOM_mixed_layer_restrat.F90
@@ -1757,7 +1757,7 @@ logical function mixedlayer_restrat_init(Time, G, GV, US, param_file, diag, CS, 
                  "Mixed layer (and mixing-layer) depths in the MLE restratification "//&
                  "schemes are replaced by H / (1 + (H/H0)**P) when "//&
                  "P=MLE_TAPER_FN_POWER > 0 and H0=MLE_TAPER_FN_DEPTH > 0.", &
-                 default=0., scale=US%m_to_Z)
+                 units="m", default=0., scale=US%m_to_Z)
   call get_param(param_file, mdl, "MLE_TAPER_FN_POWER", CS%MLE_TAPER_FN_POWER, &
                  "The power of H/H0 in the MLE mixed-layer depth tapering. "//&
                  "Any positive integer may be used, but even integers are more "//&

--- a/src/tracer/MARBL_forcing_mod.F90
+++ b/src/tracer/MARBL_forcing_mod.F90
@@ -92,15 +92,15 @@ contains
     call get_param(param_file, mdl, "DUST_RATIO_THRES", CS%dust_ratio_thres, &
         "coarse/fine dust ratio threshold", units="1", default=90.)
     call get_param(param_file, mdl, "MIN_DUST_RATIO", CS%min_dust_ratio, &
-        "minimum value for dust ratio", units="1", default=9.903)
+        "minimum value for dust ratio", units="1", default=8.5)
     call get_param(param_file, mdl, "DUST_RATIO_OFFSET", CS%dust_ratio_offset, &
         "offset for dust ratio", units="1", default=-5.5)
     call get_param(param_file, mdl, "FE_BIOAVAIL_FRAC_OFFSET", CS%fe_bioavail_frac_offset, &
         "offset for iron bioavailability fraction", units="1", default=-0.0134)
     call get_param(param_file, mdl, "ATM_FE_TO_BC_RATIO", CS%atm_fe_to_bc_ratio, &
-        "atmospheric iron to black carbon ratio", units="1", default=1.33)
+        "atmospheric iron to black carbon ratio", units="1", default=1.2)
     call get_param(param_file, mdl, "SEAICE_FE_TO_BC_RATIO", CS%seaice_fe_to_bc_ratio, &
-        "sea-ice iron to black carbon ratio", units="1", default=1.33)
+        "sea-ice iron to black carbon ratio", units="1", default=1.2)
     call get_param(param_file, mdl, "IRON_FRAC_IN_ATM_FINE_DUST", CS%iron_frac_in_atm_fine_dust, &
         "Fraction of fine dust from the atmosphere that is iron", units="1", default=0.035)
     call get_param(param_file, mdl, "IRON_FRAC_IN_ATM_COARSE_DUST", CS%iron_frac_in_atm_coarse_dust, &

--- a/src/tracer/MARBL_forcing_mod.F90
+++ b/src/tracer/MARBL_forcing_mod.F90
@@ -34,6 +34,8 @@ type, public :: marbl_forcing_CS ; private
                                              !! regulate the timing of diagnostic output.
 
   real    :: dust_ratio_thres               !< coarse/fine dust ratio threshold [1]
+  real    :: min_dust_ratio                 !< minimum value for dust ratio [1]
+  real    :: dust_ratio_offset              !< offset for dust ratio [1]
   real    :: fe_bioavail_frac_offset        !< offset for iron bioavailability fraction [1]
   real    :: atm_fe_to_bc_ratio             !< atmospheric iron to black carbon ratio [1]
   real    :: seaice_fe_to_bc_ratio          !< sea-ice iron to black carbon ratio [1]
@@ -89,6 +91,12 @@ contains
 
     call get_param(param_file, mdl, "DUST_RATIO_THRES", CS%dust_ratio_thres, &
         "coarse/fine dust ratio threshold", units="1", default=90.)
+    call get_param(param_file, mdl, "MIN_DUST_RATIO", CS%min_dust_ratio, &
+        "minimum value for dust ratio", units="1", default=9.903)
+    call get_param(param_file, mdl, "DUST_RATIO_OFFSET", CS%dust_ratio_offset, &
+        "offset for dust ratio", units="1", default=-5.5)
+    call get_param(param_file, mdl, "FE_BIOAVAIL_FRAC_OFFSET", CS%fe_bioavail_frac_offset, &
+        "offset for iron bioavailability fraction", units="1", default=-0.0134)
     call get_param(param_file, mdl, "ATM_FE_TO_BC_RATIO", CS%atm_fe_to_bc_ratio, &
         "atmospheric iron to black carbon ratio", units="1", default=1.33)
     call get_param(param_file, mdl, "SEAICE_FE_TO_BC_RATIO", CS%seaice_fe_to_bc_ratio, &
@@ -279,13 +287,13 @@ contains
         ! Contribution of atmospheric dust to iron flux
         atm_fe_bioavail_frac = 0.005
         if ((atm_coarse_dust_flux(i-i0,j-j0) > 0.) .and. (atm_fine_dust_flux(i-i0,j-j0)) > 0.) then
-          dust_ratio = max(atm_coarse_dust_flux(i-i0,j-j0) / atm_fine_dust_flux(i-i0,j-j0), 9.903)
+          dust_ratio = max(atm_coarse_dust_flux(i-i0,j-j0) / atm_fine_dust_flux(i-i0,j-j0), CS%min_dust_ratio)
         else
-          dust_ratio = 9.903
+          dust_ratio = CS%min_dust_ratio
         endif
-        dust_ratio = dust_ratio - 5.5
+        dust_ratio = dust_ratio + CS%dust_ratio_offset
         if (dust_ratio < CS%dust_ratio_thres) &
-          atm_fe_bioavail_frac = dust_ratio**(-0.9) - 0.0134
+          atm_fe_bioavail_frac = dust_ratio**(-0.9) + CS%fe_bioavail_frac_offset
 
         ! Contribution of atmospheric dust to iron flux
         fluxes%iron_flux(i,j) = (atm_fe_bioavail_frac * &

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -1618,7 +1618,7 @@ subroutine MARBL_tracers_column_physics(h_old, ea, eb, fluxes, dt, G, GV, US, CS
         call MARBL_instances%StatusLog%log_error_trace(&
             "MARBL_instances%interior_tendency_compute()", "MARBL_tracers_column_physics")
       endif
-      call print_marbl_log(MARBL_instances%StatusLog, G, i, j)
+      call print_marbl_log(MARBL_instances%StatusLog, G, i, j, print_lev=.true.)
       call MARBL_instances%StatusLog%erase()
 
       ! iv. Apply tendencies immediately
@@ -2330,7 +2330,7 @@ end subroutine set_riv_flux_tracer_inds
 ! TODO: some log messages come from a specific grid point, and this routine
 !       needs to include the location in the preamble
 !> This subroutine writes the contents of the MARBL log using MOM_error(NOTE, ...).
-subroutine print_marbl_log(log_to_print, G, i, j)
+subroutine print_marbl_log(log_to_print, G, i, j, print_lev)
 
   use marbl_logging, only : marbl_status_log_entry_type
   use marbl_logging, only : marbl_log_type
@@ -2340,12 +2340,16 @@ subroutine print_marbl_log(log_to_print, G, i, j)
   type(ocean_grid_type), optional, intent(in) :: G             !< The ocean's grid structure
   integer,               optional, intent(in) :: i             !< i of (i,j) index of column providing the log
   integer,               optional, intent(in) :: j             !< j of (i,j) index of column providing the log
+  logical,               optional, intent(in) :: print_lev     !< if true, print "Level: {ElementInd}"
 
   character(len=*), parameter :: subname = 'MARBL_tracers:print_marbl_log'
   character(len=256)          :: message_prefix, message_location, log_message
   type(marbl_status_log_entry_type), pointer :: tmp
   integer :: msg_lev, elem_old
+  logical :: print_lev_loc
 
+  print_lev_loc = .false.
+  if (present(print_lev)) print_lev_loc = print_lev
   ! elem_old is used to keep track of whether all messages are coming from the same point
   elem_old = -1
   write(message_prefix, "(A,I0,A)") '(Task ', PE_here(), ')'
@@ -2361,8 +2365,9 @@ subroutine print_marbl_log(log_to_print, G, i, j)
           if (present(i) .and. present(j)) then
             write(message_location, "(A,F8.3,A,F7.3,A,I0,A,I0,A,I0)") &
                 'Message from (lon, lat) (', G%geoLonT(i,j), ', ', G%geoLatT(i,j), &
-                '), which is global (i,j) (', i + G%HI%idg_offset, ', ', j + G%HI%jdg_offset, &
-                '). Level: ', tmp%ElementInd
+                '), which is global (i,j) (', i + G%HI%idg_offset, ', ', j + G%HI%jdg_offset, ')'
+            if (print_lev_loc) &
+              write(message_location, "(2A,I0)") trim(message_location), ' Level: ', tmp%ElementInd
           else
             write(message_location, "(A)") "Grid cell responsible for message is unknown"
           endif ! i,j present

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -2366,10 +2366,9 @@ subroutine print_marbl_log(log_to_print, G, i, j, print_lev)
           if (present(i) .and. present(j)) then
             write(message_location, "(A,F8.3,A,F7.3,A,I0,A,I0,A)") &
                 'Message from (lon, lat) (', G%geoLonT(i,j), ', ', G%geoLatT(i,j), &
-                '), which is global (i,j) (', i + G%HI%idg_offset, ', ', j + G%HI%jdg_offset, &
-                ')'
+                '), global (i,j) (', i + G%HI%idg_offset, ', ', j + G%HI%jdg_offset, ')'
             if (print_lev_loc) then
-              write(message_suffix, "(A,I0)") '. Level: ', tmp%ElementInd
+              write(message_suffix, "(A,I0)") ', level ', tmp%ElementInd
               message_location = trim(message_location) // trim(message_suffix)
             endif
           else

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -138,10 +138,10 @@ type, public :: MARBL_tracers_CS ; private
   type(vardesc), allocatable :: tr_desc(:) !< Descriptions and metadata for the tracers
   logical :: tracers_may_reinit            !< If true the tracers may be initialized if not found in a restart file
 
-  character(len=256) :: feflux_input_file      !< name of [netCDF] file containing iron sediment fluxes and vent flux
-  character(len=32) :: fe_sedflux_var_name     !< name of iron sediment flux variable in feflux_input_file
-  character(len=32) :: fe_redsedflux_var_name  !< name of iron red sediment flux variable in feflux_input_file
-  character(len=32) :: fe_ventflux_var_name    !< name of iron vent flux variable in feflux_input_file
+  character(len=256) :: fe_interior_source_file  !< name of [netCDF] file containing iron sediment and vent sources
+  character(len=32) :: fe_source_sed_name        !< name of iron sediment source variable in fe_interior_source_file
+  character(len=32) :: fe_source_redsed_name     !< name of iron red sediment source variable in fe_interior_source_file
+  character(len=32) :: fe_source_vent_name       !< name of iron vent source variable in fe_interior_source_file
   type(forcing_timeseries_dataset) :: d14c_dataset(3) !< File and time axis information for d14c forcing
   real, dimension(3) :: d14c_bands       !< forcing is organized into bands: [30 N, 90 N]; [30 S, 30 N]; [90 S, 30 S]
                                          !! This variable contains D14C for each band [CU ~> conc]
@@ -644,24 +644,24 @@ function register_MARBL_tracers(HI, GV, US, param_file, CS, tr_Reg, restart_CS, 
       default=.false.)
   if (CS%base_bio_on) then
     ! ** Fe Fluxes
-    call get_param(param_file, mdl, "MARBL_FEFLUX_FILE", CS%feflux_input_file, &
-        "The file in which the iron sediment fluxes and vent flux forcing fields can be found.", &
-        default="feflux.nc")
-    if (scan(CS%feflux_input_file,'/') == 0) then
-      ! Add the directory if CS%feflux_input_file is not already a complete path.
-      CS%feflux_input_file = trim(slasher(inputdir))//trim(CS%feflux_input_file)
-      call log_param(param_file, mdl, "INPUTDIR/MARBL_FEFLUX_FILE", CS%feflux_input_file)
+    call get_param(param_file, mdl, "MARBL_FE_INTERIOR_SOURCE_FILE", CS%fe_interior_source_file, &
+        "The file in which the iron sediment and vent source forcing fields can be found.", &
+        default="fe_interior_source.nc")
+    if (scan(CS%fe_interior_source_file,'/') == 0) then
+      ! Add the directory if CS%fe_interior_source_file is not already a complete path.
+      CS%fe_interior_source_file = trim(slasher(inputdir))//trim(CS%fe_interior_source_file)
+      call log_param(param_file, mdl, "INPUTDIR/MARBL_FE_INTERIOR_SOURCE_FILE", CS%fe_interior_source_file)
     endif
     ! ** Variable Names for Fe Fluxes
-    call get_param(param_file, mdl, "MARBL_FESEDFLUX_VAR", CS%fe_sedflux_var_name, &
-        "The name of the iron sediment flux variable in MARBL_FEFLUX_FILE.", &
-        default="FESEDFLUX")
-    call get_param(param_file, mdl, "MARBL_FEREDSEDFLUX_VAR", CS%fe_redsedflux_var_name, &
-        "The name of the iron red sediment flux variable in MARBL_FEFLUX_FILE.", &
-        default="FEREDSEDFLUX")
-    call get_param(param_file, mdl, "MARBL_FEVENTFLUX_VAR", CS%fe_ventflux_var_name, &
-        "The name of the iron vent flux variable in MARBL_FEFLUX_FILE.", &
-        default="FEVENTFLUX")
+    call get_param(param_file, mdl, "MARBL_FESEDFLUX_VAR", CS%fe_source_sed_name, &
+        "The name of the iron sediment source variable in MARBL_FE_INTERIOR_SOURCE_FILE.", &
+        default="FE_SOURCE_SED")
+    call get_param(param_file, mdl, "MARBL_FEREDSEDFLUX_VAR", CS%fe_source_redsed_name, &
+        "The name of the iron red sediment source variable in MARBL_FE_INTERIOR_SOURCE_FILE.", &
+        default="FE_SOURCE_REDSED")
+    call get_param(param_file, mdl, "MARBL_FEVENTFLUX_VAR", CS%fe_source_vent_name, &
+        "The name of the iron vent source variable in MARBL_FE_INTERIOR_SOURCE_FILE.", &
+        default="FE_SOURCE_VENT")
     ! ** Scale factor for FESEDFLUX
     call get_param(param_file, mdl, "MARBL_FESEDFLUX_SCALE_FACTOR", CS%fesedflux_scale_factor, &
         "Conversion factor between FESEDFLUX file units and MARBL units", &
@@ -1102,10 +1102,10 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
   endif
 
   if (CS%base_bio_on) then
-    ! Read initial fesedflux and feventflux fields from feflux_input_file
+    ! Read initial fesedflux and feventflux fields from fe_interior_source_file
     !     -- note: read_Z_edges treats depth as positive UP => 0 at surface, negative at depth
     fesedflux_use_missing = .false.
-    call read_Z_edges(CS%feflux_input_file, trim(CS%fe_sedflux_var_name), CS%fesedflux_z_edges, &
+    call read_Z_edges(CS%fe_interior_source_file, trim(CS%fe_source_sed_name), CS%fesedflux_z_edges, &
         CS%fesedflux_nz, fesedflux_has_edges, fesedflux_use_missing, fesedflux_missing, scale=US%m_to_Z, &
         missing_scale=1.0)
 
@@ -1117,11 +1117,11 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
 
     ! (3) Read data
     !     TODO: Add US term to scale
-    call MOM_read_data(CS%feflux_input_file, trim(CS%fe_sedflux_var_name), CS%fesedflux_in(:,:,:), &
+    call MOM_read_data(CS%fe_interior_source_file, trim(CS%fe_source_sed_name), CS%fesedflux_in(:,:,:), &
         G%Domain, scale=CS%fesedflux_scale_factor)
-    call MOM_read_data(CS%feflux_input_file, trim(CS%fe_redsedflux_var_name), CS%fesedfluxred_in(:,:,:), &
+    call MOM_read_data(CS%fe_interior_source_file, trim(CS%fe_source_redsed_name), CS%fesedfluxred_in(:,:,:), &
         G%Domain, scale=CS%fesedflux_scale_factor)
-    call MOM_read_data(CS%feflux_input_file, trim(CS%fe_ventflux_var_name), CS%feventflux_in(:,:,:), &
+    call MOM_read_data(CS%fe_interior_source_file, trim(CS%fe_source_vent_name), CS%feventflux_in(:,:,:), &
         G%Domain, scale=CS%fesedflux_scale_factor)
 
     ! (4) Relocate values that are below ocean bottom to layer that intersects bathymetry

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -26,7 +26,7 @@ use MOM_io,              only : file_exists, MOM_read_data, slasher, vardesc, va
 use MOM_open_boundary,   only : ocean_OBC_type
 use MOM_remapping,       only : reintegrate_column
 use MOM_remapping,       only : remapping_CS, initialize_remapping, remapping_core_h
-use MOM_restart,         only : query_initialized, MOM_restart_CS, register_restart_field
+use MOM_restart,         only : query_initialized, set_initialized, MOM_restart_CS, register_restart_field
 use MOM_spatial_means,   only : global_mass_int_EFP
 use MOM_sponge,          only : set_up_sponge_field, sponge_CS
 use MOM_time_manager,    only : time_type
@@ -992,6 +992,7 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
       else
         call MOM_read_data(CS%IC_file, trim(name), CS%tracer_data(m)%tr, G%Domain)
       end if
+      call set_initialized(CS%tracer_data(m)%tr, name, CS%restart_CSp)
       do k=1,GV%ke ; do j=G%jsc, G%jec ; do i=G%isc, G%iec
         ! Ensure tracer concentrations are at / above minimum value
         if (CS%tracer_data(m)%tr(i,j,k) < CS%IC_min) CS%tracer_data(m)%tr(i,j,k) = CS%IC_min

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -2343,7 +2343,8 @@ subroutine print_marbl_log(log_to_print, G, i, j, print_lev)
   logical,               optional, intent(in) :: print_lev     !< if true, print "Level: {ElementInd}"
 
   character(len=*), parameter :: subname = 'MARBL_tracers:print_marbl_log'
-  character(len=256)          :: message_prefix, message_location, log_message
+  character(len=256)          :: message_location, log_message
+  character(len=16)           :: message_prefix, message_suffix
   type(marbl_status_log_entry_type), pointer :: tmp
   integer :: msg_lev, elem_old
   logical :: print_lev_loc
@@ -2363,11 +2364,14 @@ subroutine print_marbl_log(log_to_print, G, i, j, print_lev)
       if ((present(G)) .and. (tmp%ElementInd .ne. elem_old)) then
         if (tmp%ElementInd .gt. 0) then
           if (present(i) .and. present(j)) then
-            write(message_location, "(A,F8.3,A,F7.3,A,I0,A,I0,A,I0)") &
+            write(message_location, "(A,F8.3,A,F7.3,A,I0,A,I0,A)") &
                 'Message from (lon, lat) (', G%geoLonT(i,j), ', ', G%geoLatT(i,j), &
-                '), which is global (i,j) (', i + G%HI%idg_offset, ', ', j + G%HI%jdg_offset, ')'
-            if (print_lev_loc) &
-              write(message_location, "(2A,I0)") trim(message_location), ' Level: ', tmp%ElementInd
+                '), which is global (i,j) (', i + G%HI%idg_offset, ', ', j + G%HI%jdg_offset, &
+                ')'
+            if (print_lev_loc) then
+              write(message_suffix, "(A,I0)"), '. Level: ', tmp%ElementInd
+              message_location = trim(message_location) // trim(message_suffix)
+            endif
           else
             write(message_location, "(A)") "Grid cell responsible for message is unknown"
           endif ! i,j present

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -121,8 +121,9 @@ type, public :: MARBL_tracers_CS ; private
   logical :: request_Chl_from_MARBL     !< MARBL can provide Chl to use in set_pen_shortwave()
   integer :: ice_ncat                   !< Number of ice categories when use_ice_category_fields = True
   real    :: IC_min                     !< Minimum value for tracer initial conditions [CU ~> conc]
-  character(len=200) :: IC_file !< The file in which the age-tracer initial values cam be found.
+  character(len=200) :: IC_file         !< The file in which the age-tracer initial values cam be found.
   logical :: ongrid                     !< True if IC_file is already interpolated to MOM grid
+  logical :: Z_IC_file                  !< True if IC_file has Z coordinates
   type(tracer_registry_type), pointer :: tr_Reg => NULL() !< A pointer to the tracer registry
   type(MARBL_tracer_data), dimension(:), allocatable :: tracer_data  !< type containing tracer data and pointer
                                                                      !! into tracer registry
@@ -624,6 +625,9 @@ function register_MARBL_tracers(HI, GV, US, param_file, CS, tr_Reg, restart_CS, 
   call get_param(param_file, mdl, "MARBL_TRACERS_IC_FILE", CS%IC_file, &
       "The file in which the MARBL tracers initial values can be found.", &
       default="ecosys_jan_IC_omip_latlon_1x1_180W_c230331.nc")
+  call get_param(param_file, mdl, "MARBL_TRACERS_IC_FILE_IS_Z", CS%Z_IC_file, &
+      "If true, MARBL_TRACERS_IC_FILE_IS_Z is in depth space, not layer space.", &
+      default=.true.)
   if (scan(CS%IC_file,'/') == 0) then
     ! Add the directory if CS%IC_file is not already a complete path.
     CS%IC_file = trim(slasher(inputdir))//trim(CS%IC_file)
@@ -981,9 +985,13 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
         (CS%tracers_may_reinit .and. &
          .not. query_initialized(CS%tracer_data(m)%tr(:,:,:), name, CS%restart_CSp))) then
       ! TODO: added the ongrid optional argument, but is there a good way to detect if the file is on grid?
-      call MOM_initialize_tracer_from_Z(h, CS%tracer_data(m)%tr, G, GV, US, param_file, &
-          CS%IC_file, name, ongrid=CS%ongrid)
-      tracer_init_from_Z = .true.
+      if (CS%Z_IC_file) then
+        call MOM_initialize_tracer_from_Z(h, CS%tracer_data(m)%tr, G, GV, US, param_file, &
+            CS%IC_file, name, ongrid=CS%ongrid)
+        tracer_init_from_Z = .true.
+      else
+        call MOM_read_data(CS%IC_file, trim(name), CS%tracer_data(m)%tr, G%Domain)
+      end if
       do k=1,GV%ke ; do j=G%jsc, G%jec ; do i=G%isc, G%iec
         ! Ensure tracer concentrations are at / above minimum value
         if (CS%tracer_data(m)%tr(i,j,k) < CS%IC_min) CS%tracer_data(m)%tr(i,j,k) = CS%IC_min

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -2369,7 +2369,7 @@ subroutine print_marbl_log(log_to_print, G, i, j, print_lev)
                 '), which is global (i,j) (', i + G%HI%idg_offset, ', ', j + G%HI%jdg_offset, &
                 ')'
             if (print_lev_loc) then
-              write(message_suffix, "(A,I0)"), '. Level: ', tmp%ElementInd
+              write(message_suffix, "(A,I0)") '. Level: ', tmp%ElementInd
               message_location = trim(message_location) // trim(message_suffix)
             endif
           else

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -120,7 +120,8 @@ type, public :: MARBL_tracers_CS ; private
   logical :: use_ice_category_fields    !< Forcing will include multiple ice categories for ice_frac and shortwave
   logical :: request_Chl_from_MARBL     !< MARBL can provide Chl to use in set_pen_shortwave()
   integer :: ice_ncat                   !< Number of ice categories when use_ice_category_fields = True
-  real    :: IC_min                     !< Minimum value for tracer initial conditions [CU ~> conc]
+  real    :: IC_min                     !< Minimum value for tracer initial conditions
+                                        !! (when initializing from Z) [CU ~> conc]
   character(len=200) :: IC_file         !< The file in which the age-tracer initial values cam be found.
   logical :: ongrid                     !< True if IC_file is already interpolated to MOM grid
   logical :: Z_IC_file                  !< True if IC_file has Z coordinates
@@ -335,9 +336,6 @@ subroutine configure_MARBL_tracers(GV, US, param_file, CS)
   call log_version(param_file, mdl, version, "")
   call get_param(param_file, mdl, "DEBUG", CS%debug, "If true, write out verbose debugging data.", &
        default=.false., debuggingParam=.true.)
-  call get_param(param_file, mdl, "MARBL_IC_MIN_VAL", CS%IC_min, &
-      "Minimum value of tracer initial conditions (set to 1e-100 for dim scaling tests)", &
-      default=0., units="tracer units")
   call get_param(param_file, mdl, "MARBL_SETTINGS_FILE", CS%marbl_settings_file, &
       "The name of a file from which to read the run-time settings for MARBL.", default="marbl_in")
   call get_param(param_file, mdl, "BOT_FLUX_MIX_THICKNESS", CS%bot_flux_mix_thickness, &
@@ -626,13 +624,19 @@ function register_MARBL_tracers(HI, GV, US, param_file, CS, tr_Reg, restart_CS, 
   call get_param(param_file, mdl, "MARBL_TRACERS_IC_FILE", CS%IC_file, &
       "The file in which the MARBL tracers initial values can be found.", &
       default="ecosys_jan_IC_omip_latlon_1x1_180W_c230331.nc")
-  call get_param(param_file, mdl, "MARBL_TRACERS_IC_FILE_IS_Z", CS%Z_IC_file, &
-      "If true, MARBL_TRACERS_IC_FILE_IS_Z is in depth space, not layer space.", &
-      default=.true.)
   if (scan(CS%IC_file,'/') == 0) then
     ! Add the directory if CS%IC_file is not already a complete path.
     CS%IC_file = trim(slasher(inputdir))//trim(CS%IC_file)
     call log_param(param_file, mdl, "INPUTDIR/MARBL_TRACERS_IC_FILE", CS%IC_file)
+  endif
+  call get_param(param_file, mdl, "MARBL_TRACERS_IC_FILE_IS_Z", CS%Z_IC_file, &
+      "If true, MARBL_TRACERS_IC_FILE_IS_Z is in depth space, not layer space.", &
+      default=.true.)
+  if (CS%Z_IC_file) then
+      ! When reading IC files on Z grid, want to impose minimum value
+      call get_param(param_file, mdl, "MARBL_IC_MIN_VAL", CS%IC_min, &
+          "Minimum value of tracer initial conditions (when initializing from Z)", &
+          default=0., units="tracer units")
   endif
   call get_param(param_file, mdl, "MARBL_TRACERS_MAY_REINIT", CS%tracers_may_reinit, &
       "If true, tracers may go through the initialization code if they are not found in the "//&
@@ -987,22 +991,26 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
       end if
       call set_initialized(CS%tracer_data(m)%tr, name, CS%restart_CSp)
       do k=1,GV%ke ; do j=G%jsc, G%jec ; do i=G%isc, G%iec
-        ! Ensure tracer concentrations are at / above minimum value
-        if (CS%tracer_data(m)%tr(i,j,k) < CS%IC_min) CS%tracer_data(m)%tr(i,j,k) = CS%IC_min
       enddo ; enddo ; enddo
     endif
   enddo
   if (tracer_init_from_Z) then
-    ! For each column, enforce consistency in MARBL tracers
-    ! (no negative concentrations; for a given autotroph, if one tracer is 0 they all are)
+    ! For each column, enforce consistency in MARBL tracers:
+    ! 1. Apply minimum IC value
+    ! 2. For a given autotroph, if one tracer is 0 they all are
     call MOM_error(NOTE, 'Enforcing consistency across autotroph tracer initial conditions')
     do j=G%jsc, G%jec ; do i=G%isc, G%iec
-      ! Copy tracer data into flat array
       do k=1,GV%ke; do m=1, CS%ntr
+        ! Ensure tracer concentrations are at / above minimum value
+        if (CS%tracer_data(m)%tr(i,j,k) < CS%IC_min) CS%tracer_data(m)%tr(i,j,k) = CS%IC_min
+
+        ! Copy tracer data into flat array
         MARBL_instances%tracers(m,k) = CS%tracer_data(m)%tr(i,j,k)
       end do ; end do
+
       ! call consistency enforcement
       call MARBL_instances%autotroph_tracer_consistency_enforce()
+
       ! Copy tracer data out of flat array
       do k=1,GV%ke; do m=1, CS%ntr
         CS%tracer_data(m)%tr(i,j,k) = MARBL_instances%tracers(m,k)

--- a/src/tracer/MARBL_tracers.F90
+++ b/src/tracer/MARBL_tracers.F90
@@ -138,9 +138,10 @@ type, public :: MARBL_tracers_CS ; private
   type(vardesc), allocatable :: tr_desc(:) !< Descriptions and metadata for the tracers
   logical :: tracers_may_reinit            !< If true the tracers may be initialized if not found in a restart file
 
-  character(len=200) :: fesedflux_file      !< name of [netCDF] file containing iron sediment flux
-  character(len=200) :: fesedfluxred_file   !< name of [netCDF] file containing reduced iron sediment flux
-  character(len=200) :: feventflux_file     !< name of [netCDF] file containing iron vent flux
+  character(len=256) :: feflux_input_file      !< name of [netCDF] file containing iron sediment fluxes and vent flux
+  character(len=32) :: fe_sedflux_var_name     !< name of iron sediment flux variable in feflux_input_file
+  character(len=32) :: fe_redsedflux_var_name  !< name of iron red sediment flux variable in feflux_input_file
+  character(len=32) :: fe_ventflux_var_name    !< name of iron vent flux variable in feflux_input_file
   type(forcing_timeseries_dataset) :: d14c_dataset(3) !< File and time axis information for d14c forcing
   real, dimension(3) :: d14c_bands       !< forcing is organized into bands: [30 N, 90 N]; [30 S, 30 N]; [90 S, 30 S]
                                          !! This variable contains D14C for each band [CU ~> conc]
@@ -642,33 +643,25 @@ function register_MARBL_tracers(HI, GV, US, param_file, CS, tr_Reg, restart_CS, 
       "missing ocean values is done using an ICE-9 procedure with vertical ALE remapping .", &
       default=.false.)
   if (CS%base_bio_on) then
-    ! ** FESEDFLUX
-    call get_param(param_file, mdl, "MARBL_FESEDFLUX_FILE", CS%fesedflux_file, &
-        "The file in which the iron sediment flux forcing field can be found.", &
-        default="fesedflux.nc")
-    if (scan(CS%fesedflux_file,'/') == 0) then
-      ! Add the directory if CS%fesedflux_file is not already a complete path.
-      CS%fesedflux_file = trim(slasher(inputdir))//trim(CS%fesedflux_file)
-      call log_param(param_file, mdl, "INPUTDIR/MARBL_TRACERS_FESEDFLUX_FILE", CS%fesedflux_file)
+    ! ** Fe Fluxes
+    call get_param(param_file, mdl, "MARBL_FEFLUX_FILE", CS%feflux_input_file, &
+        "The file in which the iron sediment fluxes and vent flux forcing fields can be found.", &
+        default="feflux.nc")
+    if (scan(CS%feflux_input_file,'/') == 0) then
+      ! Add the directory if CS%feflux_input_file is not already a complete path.
+      CS%feflux_input_file = trim(slasher(inputdir))//trim(CS%feflux_input_file)
+      call log_param(param_file, mdl, "INPUTDIR/MARBL_FEFLUX_FILE", CS%feflux_input_file)
     endif
-    ! ** FESEDFLUXRED
-    call get_param(param_file, mdl, "MARBL_FESEDFLUXRED_FILE", CS%fesedfluxred_file, &
-        "The file in which the iron sediment flux forcing field can be found.", &
-        default="fesedfluxred.nc")
-    if (scan(CS%fesedfluxred_file,'/') == 0) then
-      ! Add the directory if CS%fesedflux_file is not already a complete path.
-      CS%fesedfluxred_file = trim(slasher(inputdir))//trim(CS%fesedfluxred_file)
-      call log_param(param_file, mdl, "INPUTDIR/MARBL_TRACERS_FESEDFLUXRED_FILE", CS%fesedfluxred_file)
-    endif
-    ! ** FEVENTFLUX
-    call get_param(param_file, mdl, "MARBL_FEVENTFLUX_FILE", CS%feventflux_file, &
-        "The file in which the iron vent flux forcing field can be found.", &
-        default="feventflux.nc")
-    if (scan(CS%feventflux_file,'/') == 0) then
-      ! Add the directory if CS%feventflux_file is not already a complete path.
-      CS%feventflux_file = trim(slasher(inputdir))//trim(CS%feventflux_file)
-      call log_param(param_file, mdl, "INPUTDIR/MARBL_TRACERS_FEVENTFLUX_FILE", CS%feventflux_file)
-    endif
+    ! ** Variable Names for Fe Fluxes
+    call get_param(param_file, mdl, "MARBL_FESEDFLUX_VAR", CS%fe_sedflux_var_name, &
+        "The name of the iron sediment flux variable in MARBL_FEFLUX_FILE.", &
+        default="FESEDFLUX")
+    call get_param(param_file, mdl, "MARBL_FEREDSEDFLUX_VAR", CS%fe_redsedflux_var_name, &
+        "The name of the iron red sediment flux variable in MARBL_FEFLUX_FILE.", &
+        default="FEREDSEDFLUX")
+    call get_param(param_file, mdl, "MARBL_FEVENTFLUX_VAR", CS%fe_ventflux_var_name, &
+        "The name of the iron vent flux variable in MARBL_FEFLUX_FILE.", &
+        default="FEVENTFLUX")
     ! ** Scale factor for FESEDFLUX
     call get_param(param_file, mdl, "MARBL_FESEDFLUX_SCALE_FACTOR", CS%fesedflux_scale_factor, &
         "Conversion factor between FESEDFLUX file units and MARBL units", &
@@ -1109,14 +1102,11 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
   endif
 
   if (CS%base_bio_on) then
-    ! Read initial fesedflux and feventflux fields
-    ! (1) get vertical dimension
-    !     -- comes from fesedflux_file, assume same dimension in feventflux
-    !        (maybe these fields should be combined?)
+    ! Read initial fesedflux and feventflux fields from feflux_input_file
     !     -- note: read_Z_edges treats depth as positive UP => 0 at surface, negative at depth
     fesedflux_use_missing = .false.
-    call read_Z_edges(CS%fesedflux_file, "FESEDFLUXIN", CS%fesedflux_z_edges, CS%fesedflux_nz, &
-        fesedflux_has_edges, fesedflux_use_missing, fesedflux_missing, scale=US%m_to_Z, &
+    call read_Z_edges(CS%feflux_input_file, trim(CS%fe_sedflux_var_name), CS%fesedflux_z_edges, &
+        CS%fesedflux_nz, fesedflux_has_edges, fesedflux_use_missing, fesedflux_missing, scale=US%m_to_Z, &
         missing_scale=1.0)
 
     ! (2) Allocate memory for fesedflux and feventflux
@@ -1127,12 +1117,12 @@ subroutine initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag
 
     ! (3) Read data
     !     TODO: Add US term to scale
-    call MOM_read_data(CS%fesedflux_file, "FESEDFLUXIN", CS%fesedflux_in(:,:,:), G%Domain, &
-        scale=CS%fesedflux_scale_factor)
-    call MOM_read_data(CS%fesedfluxred_file, "FESEDFLUXIN", CS%fesedfluxred_in(:,:,:), G%Domain, &
-        scale=CS%fesedflux_scale_factor)
-    call MOM_read_data(CS%feventflux_file, "FESEDFLUXIN", CS%feventflux_in(:,:,:), G%Domain, &
-        scale=CS%fesedflux_scale_factor)
+    call MOM_read_data(CS%feflux_input_file, trim(CS%fe_sedflux_var_name), CS%fesedflux_in(:,:,:), &
+        G%Domain, scale=CS%fesedflux_scale_factor)
+    call MOM_read_data(CS%feflux_input_file, trim(CS%fe_redsedflux_var_name), CS%fesedfluxred_in(:,:,:), &
+        G%Domain, scale=CS%fesedflux_scale_factor)
+    call MOM_read_data(CS%feflux_input_file, trim(CS%fe_ventflux_var_name), CS%feventflux_in(:,:,:), &
+        G%Domain, scale=CS%fesedflux_scale_factor)
 
     ! (4) Relocate values that are below ocean bottom to layer that intersects bathymetry
     !     Remember, fesedflux_z_edges = 0 at surface and is < 0 below surface


### PR DESCRIPTION
This PR adds the ability to 'taper' the mixed layer and boundary layer depths in the MLE scheme. This is controlled by two new parameters: `MLE_TAPER_FN_DEPTH` and `MLE_TAPER_FN_POWER`.  When both new parameters are positive, the depth that the MLE scheme sees, denoted $H$, is replaced by

$$\frac{H}{1 + (H/H_0)^P}$$

where $P$ is `MLE_TAPER_FN_POWER` and $H_0$ is `MLE_TAPER_FN_DEPTH`. In the OM4 MLE scheme this is applied to $H=$ `MLD_fast`. In the Bodner MLE scheme this is applied to both `big_H` and `little_h`. For very deep mixed layers $H\gg H_0$ this effectively turns off the MLE restratification scheme, both by reducing the amplitude of the overturning (which scales with $H$) and by reducing the depth $H$ over which the parameterization is applied.

Note that this function does not directly modify any state variables, nor does it directly change the mixed layer depth. It only changes what the MLE scheme thinks is the mixed layer depth.